### PR TITLE
kickstart: add gPXE template, change from net0 to netX

### DIFF
--- a/kickstart/gPXE.erb
+++ b/kickstart/gPXE.erb
@@ -1,0 +1,17 @@
+#!gpxe
+#kind: gPXE
+#name: Community Kickstart gPXE
+#oses:
+#- CentOS 5
+#- CentOS 6
+#- Fedora 16
+#- Fedora 17
+#- Fedora 18
+#- Fedora 19
+#- RedHat 5
+#- RedHat 6
+
+kernel <%= "#{@host.url_for_boot(:kernel)}" %> ks=<%= foreman_url("provision")%>?static=yes ksdevice=<%= @host.mac %> network kssendmac ip=${netX/ip} netmask=${netX/netmask} gateway=${netX/gateway} dns=${dns}
+initrd <%= "#{@host.url_for_boot(:initrd)}" %>
+
+boot


### PR DESCRIPTION
Again to support foreman_bootdisk which needed a slight change from the default Foreman gPXE template.

The hardcoded net0 was replaced with netX, which in gPXE means the "last opened netdev".  This means when using foreman_bootdisk, its initialisation script will pick the right device, chainload to this script and continue on the right one.  When using [our documented script](http://projects.theforeman.org/projects/1/wiki/GPXE), it will open net0, chainload to this too and it'll carry on on net0.
