### PR TITLE
Update PXELinux.erb

### DIFF
--- a/kickstart/PXELinux.erb
+++ b/kickstart/PXELinux.erb
@@ -12,6 +12,7 @@
 default linux
 label linux
 kernel <%= @kernel %>
+ipappend 2
 <% if @host.operatingsystem.name == "Fedora" and @host.operatingsystem.major.to_i > 16 -%>
 append initrd=<%= @initrd %> ks=<%= foreman_url("provision")%> ks.device=bootif network ks.sendmac
 <% else -%>


### PR DESCRIPTION
Add `ipappend 2` so that `ksdevice=bootif` will correctly detect and use the interface which was previously used for PXE.

For more information, see http://docs.fedoraproject.org/en-US/Fedora/17/html/Installation_Guide/sn-booting-from-pxe-x86.html
