### PR TITLE
Copy gPXE template to iPXE for Foreman 1.4

### DIFF
--- a/kickstart/iPXE.erb
+++ b/kickstart/iPXE.erb
@@ -1,0 +1,17 @@
+#!gpxe
+#kind: iPXE
+#name: Community Kickstart iPXE
+#oses:
+#- CentOS 5
+#- CentOS 6
+#- Fedora 16
+#- Fedora 17
+#- Fedora 18
+#- Fedora 19
+#- RedHat 5
+#- RedHat 6
+
+kernel <%= "#{@host.url_for_boot(:kernel)}" %> ks=<%= foreman_url("provision")%>?static=yes ksdevice=<%= @host.mac %> network kssendmac ip=${netX/ip} netmask=${netX/netmask} gateway=${netX/gateway} dns=${dns}
+initrd <%= "#{@host.url_for_boot(:initrd)}" %>
+
+boot


### PR DESCRIPTION
In my seeds work I'm renaming the gPXE template kind to iPXE, so this should mean the new template gets loaded.

Hopefully foreman_templates can ignore templates for kinds it doesn't know of...

Note I've left the shebang line as gpxe because the script is still compatible with both, we're just updating strings.
