### PR TITLE
Support for RHEL7 and automated kickstart testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,23 @@ for consistency we ask that they be grouped appropriately, and end in `.erb`.
 
 Have a look around the repo for examples.
 
+# Testing
+
+There is a test suite available in this repo that tries to render templates
+using dummy values passing the output to ksvalidator tool which can be found
+in Fedora and Red Hat repositories as part of _pykickstart_ package and in
+Ubuntu repositories as part of _python-pykickstart_ package.
+
+You will need ksvalidator from Fedora 20 or later to execute tests.
+Pykickstart can be installed from git easily too. Use '-l' option to get list
+of supported versions:
+
+    $ ksvalidator -l
+
+To start unit tests do something like:
+
+    $ ruby -Itest test/kickstart/provision_test.rb 
+
 # Contributing
 
 Please fork and send a pull request. Thanks!

--- a/kickstart/PXELinux.erb
+++ b/kickstart/PXELinux.erb
@@ -2,20 +2,26 @@
 kind: PXELinux
 name: Community Kickstart PXE
 oses:
+- CentOS 4
 - CentOS 5
 - CentOS 6
+- CentOS 7
 - Fedora 16
 - Fedora 17
 - Fedora 18
 - Fedora 19
+- RedHat 4
 - RedHat 5
 - RedHat 6
+- RedHat 7
 %>
 default linux
 label linux
 kernel <%= @kernel %>
 <% if @host.operatingsystem.name == "Fedora" and @host.operatingsystem.major.to_i > 16 -%>
 append initrd=<%= @initrd %> ks=<%= foreman_url("provision")%> ks.device=bootif network ks.sendmac
+<% elsif @host.operatingsystem.name != "Fedora" and @host.operatingsystem.major.to_i >= 7 -%>
+append initrd=<%= @initrd %> ks=<%= foreman_url("provision")%> network ks.sendmac
 <% else -%>
 append initrd=<%= @initrd %> ks=<%= foreman_url("provision")%> ksdevice=bootif network kssendmac
 <% end -%>

--- a/kickstart/provision.erb
+++ b/kickstart/provision.erb
@@ -2,12 +2,18 @@
 kind: provision
 name: Community Kickstart
 oses:
+- CentOS 4
 - CentOS 5
 - CentOS 6
+- CentOS 7
 - Fedora 16
 - Fedora 17
 - Fedora 18
 - Fedora 19
+%>
+<%
+  rhel_compatible = @host.operatingsystem.family == "Redhat" && @host.operatingsystem.name != "Fedora"
+  os_major = @host.operatingsystem.major.to_i
 %>
 install
 <%= @mediapath %>
@@ -17,10 +23,12 @@ keyboard us
 skipx
 network --bootproto <%= @static ? "static --ip=#{@host.ip} --netmask=#{@host.subnet.mask} --gateway=#{@host.subnet.gateway} --nameserver=#{[@host.subnet.dns_primary,@host.subnet.dns_secondary].reject{|n| n.blank?}.join(',')}" : "dhcp" %> --hostname <%= @host %>
 rootpw --iscrypted <%= root_pass %>
-firewall --<%= @host.operatingsystem.major.to_i >= 6 ? "service=" : "" %>ssh
+firewall --<%= os_major >= 6 ? "service=" : "" %>ssh
 authconfig --useshadow --passalgo=sha256 --kickstart
 timezone UTC
+<% if rhel_compatible && os_major > 4 -%>
 services --disabled autofs,gpm,sendmail,cups,iptables,ip6tables,auditd,arptables_jf,xfs,pcmcia,isdn,rawdevices,hpoj,bluetooth,openibd,avahi-daemon,avahi-dnsconfd,hidd,hplip,pcscd,restorecond,mcstrans,rhnsd,yum-updatesd
+<% end -%>
 
 <% if @host.operatingsystem.name == "Fedora" -%>
 repo --name=fedora-everything --mirrorlist=https://mirrors.fedoraproject.org/metalink?repo=fedora-<%= @host.operatingsystem.major %>&arch=<%= @host.architecture %>
@@ -28,7 +36,7 @@ repo --name=fedora-everything --mirrorlist=https://mirrors.fedoraproject.org/met
 repo --name=puppetlabs-products --baseurl=http://yum.puppetlabs.com/fedora/f<%= @host.operatingsystem.major %>/products/<%= @host.architecture %>
 repo --name=puppetlabs-deps --baseurl=http://yum.puppetlabs.com/fedora/f<%= @host.operatingsystem.major %>/dependencies/<%= @host.architecture %>
 <% end -%>
-<% elsif @host.operatingsystem.family == "Redhat" %>
+<% elsif rhel_compatible && os_major > 4 -%>
 repo --name="Extra Packages for Enterprise Linux" --mirrorlist=https://mirrors.fedoraproject.org/metalink?repo=epel-<%= @host.operatingsystem.major %>&arch=<%= @host.architecture %>
 <% if @host.params['enable-puppetlabs-repo'] && @host.params['enable-puppetlabs-repo'] == 'true' -%>
 repo --name=puppetlabs-products --baseurl=http://yum.puppetlabs.com/el/<%= @host.operatingsystem.major %>/products/<%= @host.architecture %>
@@ -36,7 +44,7 @@ repo --name=puppetlabs-deps --baseurl=http://yum.puppetlabs.com/el/<%= @host.ope
 <% end -%>
 <% end -%>
 
-<% if @host.operatingsystem.name == "Fedora" and @host.operatingsystem.major.to_i <= 16 -%>
+<% if @host.operatingsystem.name == "Fedora" and os_major <= 16 -%>
 # Bootloader exception for Fedora 16:
 bootloader --append="nofb quiet splash=quiet <%=ks_console%>" <%= grub_pass %>
 part biosboot --fstype=biosboot --size=1
@@ -64,11 +72,12 @@ puppet
 <% if @host.params['enable-puppetlabs-repo'] && @host.params['enable-puppetlabs-repo'] == 'true' -%>
 puppetlabs-release
 <% end -%>
-<%= "%end\n" if @host.operatingsystem.name == "Fedora" %>
+%end
 
 <% if @dynamic -%>
 %pre
 <%= @host.diskLayout %>
+%end
 <% end -%>
 
 %post --nochroot
@@ -79,7 +88,7 @@ exec < /dev/tty3 > /dev/tty3
 cp -va /etc/resolv.conf /mnt/sysimage/etc/resolv.conf
 /usr/bin/chvt 1
 ) 2>&1 | tee /mnt/sysimage/root/install.postnochroot.log
-<%= "%end\n" if @host.operatingsystem.name == "Fedora" %>
+%end
 
 %post
 logger "Starting anaconda <%= @host %> postinstall"
@@ -114,4 +123,4 @@ wget -q -O /dev/null --no-check-certificate <%= foreman_url %>
 ) 2>&1 | tee /root/install.post.log
 exit 0
 
-<%= "%end\n" if @host.operatingsystem.name == "Fedora" -%>
+%end

--- a/kickstart/provision_rhel.erb
+++ b/kickstart/provision_rhel.erb
@@ -2,8 +2,13 @@
 kind: provision
 name: Community Kickstart RHEL
 oses:
+- RedHat 4
 - RedHat 5
 - RedHat 6
+- RedHat 7
+%>
+<%
+  os_major = @host.operatingsystem.major.to_i
 %>
 install
 <%= @mediapath %>
@@ -13,9 +18,10 @@ keyboard us
 skipx
 network --bootproto <%= @static ? "static --ip=#{@host.ip} --netmask=#{@host.subnet.mask} --gateway=#{@host.subnet.gateway} --nameserver=#{[@host.subnet.dns_primary,@host.subnet.dns_secondary].reject{|n| n.blank?}.join(',')}" : "dhcp" %> --hostname <%= @host %>
 rootpw --iscrypted <%= root_pass %>
-firewall --<%= @host.operatingsystem.major.to_i >= 6 ? "service=" : "" %>ssh
+firewall --<%= os_major >= 6 ? "service=" : "" %>ssh
 authconfig --useshadow --passalgo=sha256 --kickstart
 timezone UTC
+<% if os_major > 4 -%>
 services --disabled autofs,gpm,sendmail,cups,iptables,ip6tables,auditd,arptables_jf,xfs,pcmcia,isdn,rawdevices,hpoj,bluetooth,openibd,avahi-daemon,avahi-dnsconfd,hidd,hplip,pcscd,restorecond,mcstrans,rhnsd,yum-updatesd
 
 repo --name="Extra Packages for Enterprise Linux" --mirrorlist=https://mirrors.fedoraproject.org/metalink?repo=epel-<%= @host.operatingsystem.major %>&arch=<%= @host.architecture %>
@@ -23,9 +29,13 @@ repo --name="Extra Packages for Enterprise Linux" --mirrorlist=https://mirrors.f
 repo --name=puppetlabs-products --baseurl=http://yum.puppetlabs.com/el/<%= @host.operatingsystem.major %>/products/<%= @host.architecture %>
 repo --name=puppetlabs-deps --baseurl=http://yum.puppetlabs.com/el/<%= @host.operatingsystem.major %>/dependencies/<%= @host.architecture %>
 <% end -%>
+<% end -%>
 
 bootloader --location=mbr --append="nofb quiet splash=quiet" <%= grub_pass %>
+<% if os_major == 5 -%>
 key --skip
+<% end -%>
+
 
 <% if @dynamic -%>
 %include /tmp/diskpart.cfg
@@ -47,10 +57,12 @@ puppet
 <% if @host.params['enable-puppetlabs-repo'] && @host.params['enable-puppetlabs-repo'] == 'true' -%>
 puppetlabs-release
 <% end -%>
+%end
 
 <% if @dynamic -%>
 %pre
 <%= @host.diskLayout %>
+%end
 <% end -%>
 
 %post --nochroot
@@ -61,6 +73,7 @@ exec < /dev/tty3 > /dev/tty3
 cp -va /etc/resolv.conf /mnt/sysimage/etc/resolv.conf
 /usr/bin/chvt 1
 ) 2>&1 | tee /mnt/sysimage/root/install.postnochroot.log
+%end
 
 %post
 logger "Starting anaconda <%= @host %> postinstall"
@@ -99,3 +112,5 @@ wget -q -O /dev/null --no-check-certificate <%= foreman_url %>
 # Sleeping an hour for debug
 ) 2>&1 | tee /root/install.post.log
 exit 0
+
+%end

--- a/test/kickstart/provision_test.rb
+++ b/test/kickstart/provision_test.rb
@@ -1,0 +1,70 @@
+gem 'minitest'
+require 'minitest/autorun'
+require 'test_helper'
+
+class TestKickstartProvision < MiniTest::Unit::TestCase
+  include TemplatesHelper
+
+  def validate_distro(template, family, name, major, minor, ksversion)
+    ns = FakeNamespace.new(family, name, major, minor)
+    code, output = validate_erb(template, ns, ksversion)
+    assert_empty output
+    assert_equal code, 0
+  end
+
+  def test_fedora_15
+    validate_distro("kickstart/provision.erb", "Redhat", "Fedora", "15", "", "F15")
+  end
+
+  def test_fedora_16
+    validate_distro("kickstart/provision.erb", "Redhat", "Fedora", "16", "", "F16")
+  end
+
+  def test_fedora_17
+    validate_distro("kickstart/provision.erb", "Redhat", "Fedora", "17", "", "F17")
+  end
+
+  def test_fedora_18
+    validate_distro("kickstart/provision.erb", "Redhat", "Fedora", "18", "", "F18")
+  end
+
+  def test_fedora_19
+    validate_distro("kickstart/provision.erb", "Redhat", "Fedora", "19", "", "F19")
+  end
+
+  def test_fedora_20
+    validate_distro("kickstart/provision.erb", "Redhat", "Fedora", "20", "", "F20")
+  end
+
+  def test_centos_4
+    validate_distro("kickstart/provision.erb", "Redhat", "CentOS", "4", "0", "RHEL4")
+  end
+
+  def test_centos_5
+    validate_distro("kickstart/provision.erb", "Redhat", "CentOS", "5", "0", "RHEL5")
+  end
+
+  def test_centos_6
+    validate_distro("kickstart/provision.erb", "Redhat", "CentOS", "6", "0", "RHEL6")
+  end
+
+  def test_centos_7
+    validate_distro("kickstart/provision.erb", "Redhat", "CentOS", "7", "0", "RHEL7")
+  end
+
+  def test_rhel_4
+    validate_distro("kickstart/provision_rhel.erb", "Redhat", "RHEL", "4", "0", "RHEL4")
+  end
+
+  def test_rhel_5
+    validate_distro("kickstart/provision_rhel.erb", "Redhat", "RHEL", "5", "0", "RHEL5")
+  end
+
+  def test_rhel_6
+    validate_distro("kickstart/provision_rhel.erb", "Redhat", "RHEL", "6", "0", "RHEL6")
+  end
+
+  def test_rhel_7
+    validate_distro("kickstart/provision_rhel.erb", "Redhat", "RHEL", "7", "0", "RHEL7")
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,0 +1,85 @@
+require 'erb'
+require 'tempfile'
+
+DISKLAYOUT = <<DL
+zerombr
+clearpart --all --initlabel
+part / --fstype=ext4 --size=1024 --grow
+part swap  --recommended
+DL
+
+class FakeStruct
+  def initialize(hash)
+    hash.each do |key, value|
+      singleton_class.send(:define_method, key) { value }
+    end 
+  end
+
+  def get_binding
+    binding
+  end
+
+  def to_s
+    as_string
+  end
+end
+
+class FakeNamespace
+  attr_reader :root_pass, :grub_pass
+  def initialize(family, name, major, minor)
+    @mediapath = "url --url http://localhost/repo/xyz"
+    @root_pass = '$1$redhat$9yxjZID8FYVlQzHGhasqW/'
+    @grub_pass = "blah"
+    @host = FakeStruct.new(
+      :operatingsystem => FakeStruct.new(
+        :name => name,
+        :family => family,
+        :major => major,
+        :minor => minor,
+        :as_string => name
+      ),
+      :architecture => "x86_64",
+      :diskLayout => DISKLAYOUT,
+      :puppetmaster => "http://localhost",
+      :params => {
+        "enable-puppetlabs-repo" => "true"
+      },
+      :as_string => name
+    )
+  end
+
+  def snippet(*args)
+    ""
+  end
+
+  def ks_console(*args)
+    "console=ttyS99"
+  end
+
+  def foreman_url(*args)
+    "http://localhost"
+  end
+end
+
+module TemplatesHelper
+  def render_erb(template, namespace)
+    erb = ::ERB.new(IO.read(template), nil, '-')
+    erb.filename = template
+    erb.result(namespace.instance_eval { binding })
+  end
+
+  def ksvalidator(version, kickstart)
+    output = `ksvalidator -v #{version} #{kickstart}`
+    [$?.to_i, output]
+  end
+
+  def validate_erb(template, namespace, ksversion)
+    t = Tempfile.new("community-templates-validate")
+    t.write(render_erb(template, namespace))
+    t.close
+    ksvalidator(ksversion, t.path)
+  ensure
+    t.unlink
+  end
+
+end


### PR DESCRIPTION
DO NOT MERGE

Yesterday I noticed there are couple of issues with RHEL7 PXE provisioning, at
least some kickstart commands need to be added. I am not there yet.

But as part of my work, I started with _community template unit testing_! I am
adding small minitest suite that validates all supported versions of
Fedoras/RHEL and clones using ksvalidator, which is obviously needed to run
these tests.

Currently we have issues I'd like to fix as part of this PR. Note some of those
errors are just warnings, that means Anaconda will not stop from provisioning,
but I noticed RHEL7 Anaconda is more strict and it is insisting on the %end
statements now. So I'd like to fix all of them.

```
$ ruby -Itest test/kickstart/provision_test.rb 
MiniTest::Unit::TestCase is now Minitest::Test. From test/kickstart/provision_test.rb:5:in `<main>'
Run options: --seed 40402


...FF..FF...FF

Finished in 1.166976s, 11.9968 runs/s, 30.8490 assertions/s.

  1) Failure:
TestKickstartProvision#test_centos_6 [test/kickstart/provision_test.rb:11]:
Expected "The following problem occurred on line 43 of the kickstart file:\n\nSection %packages does not end with %end.\n\n" to be empty.


  2) Failure:
TestKickstartProvision#test_centos_7 [test/kickstart/provision_test.rb:11]:
Expected "The following problem occurred on line 43 of the kickstart file:\n\nSection %packages does not end with %end.\n\n" to be empty.


  3) Failure:
TestKickstartProvision#test_rhel_6 [test/kickstart/provision_test.rb:11]:
Expected "The following problem occurred on line 20 of the kickstart file:\n\nUnknown command: key\n\nThe following problem occurred on line 42 of the kickstart file:\n\nSection %packages does not end with %end.\n\n" to be empty.


  4) Failure:
TestKickstartProvision#test_centos_4 [test/kickstart/provision_test.rb:11]:
Expected "The following problem occurred on line 13 of the kickstart file:\n\nUnknown command: services\n\nThe following problem occurred on line 16 of the kickstart file:\n\nUnknown command: repo\n\nThe following problem occurred on line 17 of the kickstart file:\n\nUnknown command: repo\n\nThe following problem occurred on line 18 of the kickstart file:\n\nUnknown command: repo\n\n" to be empty.


  5) Failure:
TestKickstartProvision#test_rhel_7 [test/kickstart/provision_test.rb:11]:
Expected "The following problem occurred on line 20 of the kickstart file:\n\nUnknown command: key\n\nThe following problem occurred on line 42 of the kickstart file:\n\nSection %packages does not end with %end.\n\n" to be empty.


  6) Failure:
TestKickstartProvision#test_rhel_4 [test/kickstart/provision_test.rb:11]:
Expected "The following problem occurred on line 13 of the kickstart file:\n\nUnknown command: services\n\nThe following problem occurred on line 15 of the kickstart file:\n\nUnknown command: repo\n\nThe following problem occurred on line 16 of the kickstart file:\n\nUnknown command: repo\n\nThe following problem occurred on line 17 of the kickstart file:\n\nUnknown command: repo\n\nThe following problem occurred on line 20 of the kickstart file:\n\nUnknown command: key\n\n" to be empty.

14 runs, 36 assertions, 6 failures, 0 errors, 0 skips
```
