### PR TITLE
Add userdata templates

### DIFF
--- a/kickstart/userdata.erb
+++ b/kickstart/userdata.erb
@@ -1,0 +1,35 @@
+<%#
+kind: user_data
+name: Community Kickstart UserData
+oses:
+- CentOS 4
+- CentOS 5
+- CentOS 6
+- CentOS 7
+- Fedora 16
+- Fedora 17
+- Fedora 18
+- Fedora 19
+%>
+#!/bin/bash
+
+<%# Cloud instances frequently have incorrect hosts data %>
+<%= snippet "fix_hosts" %>
+
+<%
+  # safemode renderer does not support unary negation
+  pm_set = @host.puppetmaster.empty? ? false : true
+  puppet_enabled = pm_set || @host.params['force-puppet']
+%>
+<% if puppet_enabled %>
+yum install -y puppet
+cat > /etc/puppet/puppet.conf << EOF
+<%= snippet "puppet.conf" %>
+EOF
+/bin/sed -i 's/^START=no/START=yes/' /etc/default/puppet
+/bin/touch /etc/puppet/namespaceauth.conf
+/usr/bin/puppet agent --config /etc/puppet/puppet.conf --onetime --tags no_such_tag <%= @host.puppetmaster.blank? ? "" : "--server #{@host.puppetmaster}" %> --no-daemonize
+<% end -%>
+
+# UserData still needs wget to mark as finished
+/usr/bin/wget --quiet --output-document=/dev/null --no-check-certificate <%= foreman_url('built') %>

--- a/preseed/userdata.erb
+++ b/preseed/userdata.erb
@@ -1,0 +1,31 @@
+<%#
+kind: user_data
+name: Community Preseed UserData
+oses:
+- Debian 6.0
+- Debian 7.0
+- Ubuntu 12.04
+%>
+#!/bin/bash
+
+<%# Cloud instances frequently have incorrect hosts data %>
+<%= snippet "fix_hosts" %>
+
+<%
+  # safemode renderer does not support unary negation
+  pm_set = @host.puppetmaster.empty? ? false : true
+  puppet_enabled = pm_set || @host.params['force-puppet']
+%>
+<% if puppet_enabled %>
+apt-get update
+apt-get install -y puppet
+cat > /etc/puppet/puppet.conf << EOF
+<%= snippet "puppet.conf" %>
+EOF
+/bin/sed -i 's/^START=no/START=yes/' /etc/default/puppet
+/bin/touch /etc/puppet/namespaceauth.conf
+/usr/bin/puppet agent --config /etc/puppet/puppet.conf --onetime --tags no_such_tag <%= @host.puppetmaster.blank? ? "" : "--server #{@host.puppetmaster}" %> --no-daemonize
+<% end -%>
+
+# UserData still needs wget to mark as finished
+/usr/bin/wget --quiet --output-document=/dev/null --no-check-certificate <%= foreman_url('built') %>

--- a/snippets/fix_hosts.erb
+++ b/snippets/fix_hosts.erb
@@ -1,0 +1,15 @@
+<%#
+kind: snippet
+name: fix_hosts
+%>
+echo "<%= @host.shortname %>" > /etc/hostname
+hostname <%= @host.shortname %>
+cat > /etc/hosts << EOF
+<%# simple snippet to generate /etc/hosts when provisioning image based systems -%>
+127.0.0.1   <%= @host %> <%= @host.shortname %> localhost localhost.localdomain
+::1     ip6-localhost ip6-loopback
+fe00::0 ip6-localnet
+ff00::0 ip6-mcastprefix
+ff02::1 ip6-allnodes
+ff02::2 ip6-allrouters
+EOF


### PR DESCRIPTION
Untested, but very similar to the one I actually use. The debian one should be fine, I'd appreciate a review on the rpm one.

Optional extras I haven't done:
- Enable puppetlabs repo if required (as per Kickstart/Preseed Provision)
- Combine into a single template (since only the apt/yum lines differ)
