### PR TITLE
Add iPXE/static-boot support for Debian

### DIFF
--- a/kickstart/gPXE.erb
+++ b/kickstart/gPXE.erb
@@ -13,6 +13,9 @@ oses:
 - RedHat 6
 %>
 
+<%# This template will not function with Safemode set to true.
+    Please disable it in Settings > Provisioning               %>
+
 kernel <%= "#{@host.url_for_boot(:kernel)}" %> ks=<%= foreman_url("provision")%>?static=yes ksdevice=<%= @host.mac %> network kssendmac ip=${netX/ip} netmask=${netX/netmask} gateway=${netX/gateway} dns=${dns}
 initrd <%= "#{@host.url_for_boot(:initrd)}" %>
 

--- a/kickstart/iPXE.erb
+++ b/kickstart/iPXE.erb
@@ -13,6 +13,9 @@ oses:
 - RedHat 6
 %>
 
+<%# This template will not function with Safemode set to true.
+    Please disable it in Settings > Provisioning               %>
+
 kernel <%= "#{@host.url_for_boot(:kernel)}" %> ks=<%= foreman_url("provision")%>?static=yes ksdevice=<%= @host.mac %> network kssendmac ip=${netX/ip} netmask=${netX/netmask} gateway=${netX/gateway} dns=${dns}
 initrd <%= "#{@host.url_for_boot(:initrd)}" %>
 

--- a/preseed/iPXE.erb
+++ b/preseed/iPXE.erb
@@ -1,0 +1,24 @@
+#!gpxe
+<%#
+kind: iPXE
+name: Community Preseed iPXE
+oses:
+- Debian 6.0
+- Debian 7.0
+- Ubuntu 12.04
+%>
+<% if @host.operatingsystem.name == "Debian" -%>
+<% keyboard_params = "auto=true console-keymaps-at/keymap=us keymap=us domain=#{@host.domain}" -%>
+<% else -%>
+<% keyboard_params = "console-setup/ask_detect=false console-setup/layout=USA console-setup/variant=USA keyboard-configuration/layoutcode=us" -%>
+<% end -%>
+<% kernel, initrd = @host.operatingsystem.boot_files_uri(@host.medium,@host.architecture) -%>
+<% static = @host.token.nil? ? '?static=yes' : '&static=yes' -%>
+
+<%# This template will not function with Safemode set to true.
+    Please disable it in Settings > Provisioning               %>
+
+kernel <%= kernel %> interface=auto url=<%= foreman_url("provision")%><%= static %> ramdisk_size=10800 root=/dev/rd/0 rw auto netcfg/disable_dhcp=true BOOTIF=${netX/mac} hostname=<%= @host.name %> <%= keyboard_params %> locale=en_US netcfg/get_ipaddress=${netX/ip} netcfg/get_netmask=${netX/netmask} netcfg/get_gateway=${netX/gateway} netcfg/get_nameservers=${dns} netcfg/confirm_static=true
+initrd <%= initrd %>
+
+boot

--- a/preseed/provision.erb
+++ b/preseed/provision.erb
@@ -25,6 +25,16 @@ d-i console-setup/layoutcode string us
 d-i keymap select us
 <% end -%>
 
+<% if @static -%>
+# Static network configuration.
+d-i netcfg/disable_dhcp boolean true
+d-i netcfg/get_ipaddress string <%= @host.ip %>
+d-i netcfg/get_netmask string <%= @host.subnet.mask %>
+d-i netcfg/get_nameservers string <%= [@host.subnet.dns_primary,@host.subnet.dns_secondary].reject{|n| n.blank?}.join(' ') %>
+d-i netcfg/get_gateway string <%= @host.subnet.gateway %>
+d-i netcfg/confirm_static boolean true
+<% end -%>
+
 # Network configuration
 d-i netcfg/choose_interface select auto
 d-i netcfg/get_hostname string <%= @host %>


### PR DESCRIPTION
Tested with this procedure:
- Created a network in libvirt with no DHCP
- Created a BareMetal Host if Foreman with an IP on this network
- Booted a libvirt vm using the vanilla iPXE kernel (ipxe.iso) from ipxe.org
- Manually entered netX/ip, netX/gateway, dns params
- Chainloaded the iPXE template, leading to the modified static provison

Seems to work on Wheezy, not tested the others. Going to try and fix the bootdisk plugin for easier testing :P
