### PR TITLE
Fixes #3842: add support for registering with RHSM

### DIFF
--- a/snippets/redhat_register.erb
+++ b/snippets/redhat_register.erb
@@ -4,68 +4,95 @@ name: redhat_register
 %>
 # Red Hat Registration Snippet
 #
-# Usage, set these params:
+# Set these parameters if you're using rhnreg_ks:
+#
 #   spacewalk_type = 'site'     (local Spacewalk/Satellite server)
 #                  = 'hosted'   (RHN hosted)
 #   spacewalk_host = <hostname> (hostname of Spacewalk server, optional for
 #                                RHN hosted)
-#   activation_key = <key>      (activation key string)
+#
+# Set these parameters if you're using subscription-manager:
+#
+#   subscription_manager = 'true' (you're going to use subscription-manager)
+#
+#   subscription_manager_username = <username> (if using hosted RHN)
+#
+#   subscription_manager_password = <password> (if using hosted RHN)
+#
+#   subscription_manager_host = <hostname> (hostname of SAM/Katello installation, if using SAM)
+#
+#   subscription_manager_org = <org name> (organization name, if using SAM/Katello)
+#
+# Set this parameter regardless of which registration method you're using:
+#
+#   activation_key = <key>      (activation key string, not needed if using subscription-manager with hosted RHN)
 #
 
-<%
-if @host.params['activation_key']
-    type = @host.params['spacewalk_type'] || 'hosted'
--%>
-# Discovered Activation Key <%= @host.params['activation_key'] %>
-rhn_activation_key="<%= @host.params['activation_key'] -%>"
+<% unless @host.params['subscription_manager'] %>
+  <% type = @host.params['spacewalk_type'] || 'hosted' %>
 
-<% if type == "site" -%>
-satellite_hostname="<%= @host.params['spacewalk_host'] -%>"
-rhn_cert_file="RHN-ORG-TRUSTED-SSL-CERT"
-<% else -%>
-satellite_hostname="<%= @host.params['spacewalk_host'] || 'xmlrpc.rhn.redhat.com' -%>"
-rhn_cert_file="RHNS-CA-CERT"
-<% end -%>
+  <% if @host.params['activation_key'] %>
+    # Discovered Activation Key <%= @host.params['activation_key'] %>
+    rhn_activation_key="<%= @host.params['activation_key'] -%>"
 
-echo "Registering to RHN Satellite at [$satellite_hostname]"
-echo "Using Registration Key [$rhn_activation_key]"
+    <% if type == "site" -%>
+    satellite_hostname="<%= @host.params['spacewalk_host'] -%>"
+    rhn_cert_file="RHN-ORG-TRUSTED-SSL-CERT"
+    <% else -%>
+    satellite_hostname="<%= @host.params['spacewalk_host'] || 'xmlrpc.rhn.redhat.com' -%>"
+    rhn_cert_file="RHNS-CA-CERT"
+    <% end -%>
 
-<% if type == 'site' -%>
-# Obtain our RHN Satellite Certificate
-echo "Obtaining RHN SSL certificate"
-wget http://$satellite_hostname/pub/$rhn_cert_file -O /usr/share/rhn/$rhn_cert_file
-<% end -%>
+    echo "Registering to RHN Satellite at [$satellite_hostname]"
+    echo "Using Registration Key [$rhn_activation_key]"
 
-# Update our up2date configuration file
-echo "Updating SSL CA Certificate to /usr/share/rhn/$rhn_cert_file"
-sed -i -e "s|^sslCACert=.*$|sslCACert=/usr/share/rhn/$rhn_cert_file|" /etc/sysconfig/rhn/up2date
+    <% if type == 'site' -%>
+    # Obtain our RHN Satellite Certificate
+    echo "Obtaining RHN SSL certificate"
+    wget http://$satellite_hostname/pub/$rhn_cert_file -O /usr/share/rhn/$rhn_cert_file
+    <% end -%>
 
-# Update our Satellite Hostname
-echo "Updating Satellite Hostname to [$satellite_hostname]"
-sed -i -e "s|^serverURL=.*$|serverURL=https://$satellite_hostname/XMLRPC|" /etc/sysconfig/rhn/up2date
-sed -i -e "s|^noSSLServerURL=.*$|noSSLServerURL=https://$satellite_hostname/XMLRPC|" /etc/sysconfig/rhn/up2date
+    # Update our up2date configuration file
+    echo "Updating SSL CA Certificate to /usr/share/rhn/$rhn_cert_file"
+    sed -i -e "s|^sslCACert=.*$|sslCACert=/usr/share/rhn/$rhn_cert_file|" /etc/sysconfig/rhn/up2date
 
-# Restart messagebus/HAL to try and prevent hardware detection errors in rhnreg_ks
-echo "Restarting services..."
-service messagebus restart
-service hald restart
+    # Update our Satellite Hostname
+    echo "Updating Satellite Hostname to [$satellite_hostname]"
+    sed -i -e "s|^serverURL=.*$|serverURL=https://$satellite_hostname/XMLRPC|" /etc/sysconfig/rhn/up2date
+    sed -i -e "s|^noSSLServerURL=.*$|noSSLServerURL=https://$satellite_hostname/XMLRPC|" /etc/sysconfig/rhn/up2date
 
-# Now, perform our registration
-#  (might get hardware errors here, due to dbus/messagebus lameness. These are safe to ignore.)
-echo -n "Performing RHN Registration... "
-rhnreg_ks --activationkey=$rhn_activation_key
-echo "done."
+    # Restart messagebus/HAL to try and prevent hardware detection errors in rhnreg_ks
+    echo "Restarting services..."
+    service messagebus restart
+    service hald restart
 
-# Check we registered
-echo -n "Checking System Registration... "
-if ! rhn_check; then
-    echo "FAILED"
-    echo " >> RHN Registration FAILED. Please Investigate. <<"
-else
-    echo "registration successful."
-fi
-# Done!
-<% else -%>
-# Not registering - host.params['activation_key'] not found.
-<% end -%>
+    # Now, perform our registration
+    #  (might get hardware errors here, due to dbus/messagebus lameness. These are safe to ignore.)
+    echo -n "Performing RHN Registration... "
+    rhnreg_ks --activationkey=$rhn_activation_key
+    echo "done."
+
+    # Check we registered
+    echo -n "Checking System Registration... "
+    if ! rhn_check; then
+        echo "FAILED"
+        echo " >> RHN Registration FAILED. Please Investigate. <<"
+    else
+        echo "registration successful."
+    fi
+  <% else %>
+    # Not registering - host.params['activation_key'] not found.
+  <% end %>
+<% else %>
+  echo "Starting the subscription-manager registration process"
+  yum -t -y -e 0 install subscription-manager
+  <% if @host.params['subscription_manager_username'] && @host.params['subscription_manager_password'] %>
+    subscription-manager register --username="<%= @host.params['subscription_manager_username'] %>" --password="<%= @host.params['subscription_manager_password'] %>" --auto-attach
+  <% elsif @host.params['activation_key'] %>
+    rpm -Uvh <%= @host.params['subscription_manager_host'] %>/pub/candlepin-cert-consumer-latest.noarch.rpm
+    subscription-manager register --org="<%= @host.params['subscription_manager_org'] %>" --activationkey="<%= @host.params['activation_key'] %>"
+  <% else %>
+    # Not registering host.params['activation_key'] not found.
+  <% end %>
+<% end %>
 # End Red Hat Registration Snippet


### PR DESCRIPTION
This pull request introduces support for registering with subscription-manager without changing any of the current behavior around `rhnreg_ks`. I believe I've tested each case (hosted with rhnreg_ks, standalone spacewalk with rhnreg_ks, subscription-manager with RHN, and subscription-manager with Katello/SAM), but some more testing would be good.
