### PR TITLE
Add generic memdisk PXE template

### DIFF
--- a/pxe/PXELinux_memdisk.erb
+++ b/pxe/PXELinux_memdisk.erb
@@ -1,0 +1,10 @@
+<%#
+kind: PXELinux
+name: Community Memdisk PXE
+oses:
+- FreeBSD (memdisk image)
+%>
+default memdisk
+label memdisk
+kernel memdisk
+append initrd=<%= @initrd %> harddisk raw


### PR DESCRIPTION
Add generic memdisk template (used for provisioning FreeBSD with mfsBSD)
