### PR TITLE
Error when parsing templates (master)

### DIFF
--- a/test/common/headers_test.rb
+++ b/test/common/headers_test.rb
@@ -1,0 +1,20 @@
+gem 'minitest'
+require 'minitest/autorun'
+require 'test_helper'
+require 'yaml'
+
+class TestHeaders < MiniTest::Unit::TestCase
+
+  def test_headers
+    Dir.glob("**/*.erb") do |erb|
+      extracted = IO.read(erb).match(/<%\#(.+?).-?%>/m)
+      refute_nil extracted
+      yaml = YAML.load(extracted[1])
+      refute_nil yaml
+      refute_nil yaml["kind"]
+      refute_empty yaml["kind"]
+      refute_nil yaml["name"]
+      refute_empty yaml["name"]
+    end
+  end
+end


### PR DESCRIPTION
Current master is giving me this on Foreman 1.4 RHEL6 instance:

```
[root@foreman ~]# foreman-rake templates:sync --trace
** Invoke templates:sync (first_time)
** Invoke environment (first_time)
** Execute environment
** Execute templates:sync
remote: Reusing existing pack: 526, done.
remote: Total 526 (delta 0), reused 0 (delta 0)
Receiving objects: 100% (526/526), 90.58 KiB, done.
Resolving deltas: 100% (214/214), done.
rake aborted!
(<unknown>): did not find expected key while parsing a block mapping at line 2 column 1
/opt/rh/ruby193/root/usr/share/ruby/psych.rb:203:in `parse'
/opt/rh/ruby193/root/usr/share/ruby/psych.rb:203:in `parse_stream'
/opt/rh/ruby193/root/usr/share/ruby/psych.rb:151:in `parse'
/opt/rh/ruby193/root/usr/share/ruby/psych.rb:127:in `load'
/opt/rh/ruby193/root/usr/share/gems/gems/foreman_templates-1.3.2/lib/templates.rake:14:in `metadata'
/opt/rh/ruby193/root/usr/share/gems/gems/foreman_templates-1.3.2/lib/templates.rake:137:in `block (3 levels) in <top (required)>'
/opt/rh/ruby193/root/usr/share/gems/gems/foreman_templates-1.3.2/lib/templates.rake:135:in `each'
/opt/rh/ruby193/root/usr/share/gems/gems/foreman_templates-1.3.2/lib/templates.rake:135:in `block (2 levels) in <top (required)>'
/opt/rh/ruby193/root/usr/share/ruby/rake/task.rb:205:in `call'
/opt/rh/ruby193/root/usr/share/ruby/rake/task.rb:205:in `block in execute'
/opt/rh/ruby193/root/usr/share/ruby/rake/task.rb:200:in `each'
/opt/rh/ruby193/root/usr/share/ruby/rake/task.rb:200:in `execute'
/opt/rh/ruby193/root/usr/share/ruby/rake/task.rb:158:in `block in invoke_with_call_chain'
/opt/rh/ruby193/root/usr/share/ruby/monitor.rb:211:in `mon_synchronize'
/opt/rh/ruby193/root/usr/share/ruby/rake/task.rb:151:in `invoke_with_call_chain'
/opt/rh/ruby193/root/usr/share/ruby/rake/task.rb:144:in `invoke'
/opt/rh/ruby193/root/usr/share/ruby/rake/application.rb:116:in `invoke_task'
/opt/rh/ruby193/root/usr/share/ruby/rake/application.rb:94:in `block (2 levels) in top_level'
/opt/rh/ruby193/root/usr/share/ruby/rake/application.rb:94:in `each'
/opt/rh/ruby193/root/usr/share/ruby/rake/application.rb:94:in `block in top_level'
/opt/rh/ruby193/root/usr/share/ruby/rake/application.rb:133:in `standard_exception_handling'
/opt/rh/ruby193/root/usr/share/ruby/rake/application.rb:88:in `top_level'
/opt/rh/ruby193/root/usr/share/ruby/rake/application.rb:66:in `block in run'
/opt/rh/ruby193/root/usr/share/ruby/rake/application.rb:133:in `standard_exception_handling'
/opt/rh/ruby193/root/usr/share/ruby/rake/application.rb:63:in `run'
/opt/rh/ruby193/root/usr/bin/rake:32:in `<main>'
Tasks: TOP => templates:sync
```
