### PR TITLE
change SUSE from postinst to chroot scripts

### DIFF
--- a/autoyast/provision.erb
+++ b/autoyast/provision.erb
@@ -58,7 +58,6 @@ name: Community AutoYaST
 <% if puppet_enabled %>
       <package>puppet</package>
 <% end -%>
-      <package>wget</package>
     </packages>
   </software>
   <users config:type="list">
@@ -74,13 +73,22 @@ name: Community AutoYaST
     </user>
   </users>
   <scripts>
-    <post-scripts config:type="list">
+    <chroot-scripts config:type="list">
       <script>
-        <filename>post.sh</filename>
+        <filename>cp-resolv.sh</filename>
+        <chrooted config:type="boolean">false</chrooted>
         <interpreter>shell</interpreter>
-        <network_needed config:type="boolean">true</network_needed>
+        <notification>Copying resolv.conf into chroot ...</notification>
+        <source><![CDATA[
+cp /etc/resolv.conf /mnt/etc
+]]>
+        </source>
+      </script>
+      <script>
+        <filename>foreman.sh</filename>
+        <chrooted config:type="boolean">true</chrooted>
+        <interpreter>shell</interpreter>
         <notification>Setting up Puppet / Foreman ...</notification>
-        <debug config:type="boolean">true</debug>
         <source><![CDATA[
 <% if puppet_enabled %>
           cat > /etc/puppet/puppet.conf << EOF
@@ -94,11 +102,13 @@ fi
 /sbin/chkconfig puppet on -f
 <% end -%>
 
-/usr/bin/wget -q -O /dev/null --no-check-certificate <%= foreman_url %>
+/usr/bin/curl -o /dev/null -k '<%= foreman_url %>'
+
+rm /etc/resolv.conf
 ]]>
         </source>
       </script>
-    </post-scripts>
+    </chroot-scripts>
   </scripts>
   <keyboard>
     <keymap>english-us</keymap>

--- a/autoyast/provision_sles.erb
+++ b/autoyast/provision_sles.erb
@@ -61,7 +61,6 @@ oses:
       <package>puppet</package>
       <package>rubygem-ruby-augeas</package>
 <% end -%>
-      <package>wget</package>
     </packages>
   </software>
   <users config:type="list">
@@ -77,13 +76,22 @@ oses:
     </user>
   </users>
   <scripts>
-    <post-scripts config:type="list">
+    <chroot-scripts config:type="list">
       <script>
-        <filename>post.sh</filename>
+        <filename>cp-resolv.sh</filename>
+        <chrooted config:type="boolean">false</chrooted>
         <interpreter>shell</interpreter>
-        <network_needed config:type="boolean">true</network_needed>
+        <notification>Copying resolv.conf into chroot ...</notification>
+        <source><![CDATA[
+cp /etc/resolv.conf /mnt/etc
+]]>
+        </source>
+      </script>
+      <script>
+        <filename>foreman.sh</filename>
+        <chrooted config:type="boolean">true</chrooted>
+        <interpreter>shell</interpreter>
         <notification>Setting up Puppet / Foreman ...</notification>
-        <debug config:type="boolean">true</debug>
         <source><![CDATA[
 <% if puppet_enabled %>
           cat > /etc/puppet/puppet.conf << EOF
@@ -97,11 +105,13 @@ fi
 /sbin/chkconfig puppet on -f
 <% end -%>
 
-/usr/bin/wget -q -O /dev/null --no-check-certificate <%= foreman_url %>
+/usr/bin/curl -o /dev/null -k '<%= foreman_url %>'
+
+rm /etc/resolv.conf
 ]]>
         </source>
       </script>
-    </post-scripts>
+    </chroot-scripts>
   </scripts>
   <keyboard>
     <keymap>english-us</keymap>


### PR DESCRIPTION
@mattiasgiese please ACK, these changes are based on your pastebin, I tested this with SLES 11 SP3.

"postinst" for SUSE means, these scripts get executed after the first
reboot of the host. If a host is configured to boot from PXE before
HDD, it will go into an install loop, because the built status is never
being set in foreman.

To get everything working, resolv.conf has to be copied into the
installed system image and removed before the host is booting the first
time, otherwise SUSEConfig (netconf) will not touch /etc/resolv.conf,
which is leading NTP configuration into an error.

While here, replace wget with curl (included in SUSE's base system) and
remove debug parameters, as debug=true was made default long time ago.
