### PR TITLE
preseed: always enable puppet agent explicitly

### DIFF
--- a/preseed/finish.erb
+++ b/preseed/finish.erb
@@ -17,8 +17,12 @@ oses:
 cat > /etc/puppet/puppet.conf << EOF
 <%= snippet 'puppet.conf' %>
 EOF
+if [ -f "/etc/default/puppet" ]
+then
 /bin/sed -i 's/^START=no/START=yes/' /etc/default/puppet
+fi
 /bin/touch /etc/puppet/namespaceauth.conf 
+/usr/bin/puppet agent --enable
 /usr/bin/puppet agent --config /etc/puppet/puppet.conf --onetime --tags no_such_tag <%= @host.puppetmaster.blank? ? '' : "--server #{@host.puppetmaster}" %> --no-daemonize
 <% end -%>
 

--- a/preseed/userdata.erb
+++ b/preseed/userdata.erb
@@ -22,8 +22,12 @@ apt-get install -y puppet
 cat > /etc/puppet/puppet.conf << EOF
 <%= snippet 'puppet.conf' %>
 EOF
+if [ -f "/etc/default/puppet" ]
+then
 /bin/sed -i 's/^START=no/START=yes/' /etc/default/puppet
+fi
 /bin/touch /etc/puppet/namespaceauth.conf
+/usr/bin/puppet agent --enable
 /usr/bin/puppet agent --config /etc/puppet/puppet.conf --onetime --tags no_such_tag <%= @host.puppetmaster.blank? ? '' : "--server #{@host.puppetmaster}" %> --no-daemonize
 <% end -%>
 


### PR DESCRIPTION
In newer non-puppetlabs packages coming with Debian and Ubuntu the
puppet agent is disabled by default.

Also, /etc/default/puppet is not delivered with the packages anymore, so
check for it's existence before trying to edit it.
