### PR TITLE
Add in initial generic cloudinit userdata template and snippet

### DIFF
--- a/cloudinit/userdata_cloudinit.erb
+++ b/cloudinit/userdata_cloudinit.erb
@@ -1,6 +1,6 @@
 <%#
 kind: user_data
-name: EC2 UserData using cloudinit
+name: EC2 UserData via snippets
 oses:
 - CentOS 4
 - CentOS 5
@@ -10,6 +10,11 @@ oses:
 - Fedora 17
 - Fedora 18
 - Fedora 19
+- Debian 6.0
+- Debian 7.0
+- Ubuntu 10.04
+- Ubuntu 12.04
+- Ubuntu 13.04
 -%>
 #cloud-config
 hostname: <%= @host.shortname %>
@@ -19,3 +24,4 @@ manage_etc_hosts: true
 <%# Contact Foreman to confirm instance is built -%>
 phone_home:
  url: <%= foreman_url('built') %>
+ tries: 10


### PR DESCRIPTION
This is the in initial import of generic cloudinit userdata template and snippet used in EC2 to modify the hostname on instance initial boot.
I have tested this using Foreman 1.4.1.
The code assumes that CloudInit is included in the ami / image and uses CloudConfig commands.

References for the code cane be found here:
http://cloudinit.readthedocs.org/en/latest/topics/capabilities.html

Command to call back to Foreman to confirm build is complete.
http://cloudinit.readthedocs.org/en/latest/topics/examples.html#call-a-url-when-finished

I placed the main file userdata_cloudinit.erb in a new cloudinit directory as I did not think that it should go into kickstart, etc.

I was told by gwmngilfen that I should go ahead and submit the changes and then we could discuss in the details in the PR.  

I have not made any changes to any other files, these are only additions to foster feedback.
I suspect changes will need to be mde to https://github.com/theforeman/foreman/blob/develop/db/seeds.d/07-config_templates.rb to pull the files in for usage on install of the foreman system.
