### PR TITLE
redhat_register snippet - fix enabling repos

### DIFF
--- a/snippets/redhat_register.erb
+++ b/snippets/redhat_register.erb
@@ -96,10 +96,14 @@ name: redhat_register
   <% (enabled_repos = "yum-config-manager --enable #{@host.params['subscription_manager_repos'].gsub(',', ' ')}") if @host.params['subscription_manager_repos'] %>
   <% if @host.params['subscription_manager_username'] && @host.params['subscription_manager_password'] %>
     subscription-manager register --username="<%= @host.params['subscription_manager_username'] %>" --password="<%= @host.params['subscription_manager_password'] %>" --auto-attach
+    # workaround for RHEL 6.4 bug https://bugzilla.redhat.com/show_bug.cgi?id=1008016
+    subscription-manager repos --list > /dev/null
     <%= enabled_repos if enabled_repos %>
   <% elsif @host.params['activation_key'] %>
     rpm -Uvh <%= @host.params['subscription_manager_host'] %>/pub/candlepin-cert-consumer-latest.noarch.rpm
     subscription-manager register --org="<%= @host.params['subscription_manager_org'] %>" --activationkey="<%= @host.params['activation_key'] %>"
+    # workaround for RHEL 6.4 bug https://bugzilla.redhat.com/show_bug.cgi?id=1008016
+    subscription-manager repos --list > /dev/null
     <%= enabled_repos if enabled_repos %>
   <% else %>
     # Not registering host.params['activation_key'] not found.


### PR DESCRIPTION
Related to:
https://bugzilla.redhat.com/show_bug.cgi?id=1039910

Repositories specified in `subscription_manager_repos` parameter
didn't get enabled when using redhat_register template snippet. The
`yum-config-manager --enable ...` command only works when
`/etc/yum.repos.d/redhat.repo` file already exists. But
`subscription-manager register ... --auto-attach` command will not
create the repo file. We need to run `subscription-manager repos
--list` to trigger creation of the repo file.
