### PR TITLE
Only check for @host.otp when Foreman supports it

### DIFF
--- a/kickstart/finish.erb
+++ b/kickstart/finish.erb
@@ -39,7 +39,7 @@ echo "updating system time"
 /usr/sbin/ntpdate -sub <%= @host.params['ntp-server'] || '0.fedora.pool.ntp.org' %>
 /usr/sbin/hwclock --systohc
 
-<% if @host.otp && @host.realm && @host.realm.realm_type == "FreeIPA" -%>
+<% if @host.respond_to?(:otp) && @host.otp && @host.realm && @host.realm.realm_type == "FreeIPA" -%>
 <%= snippet "freeipa_register" %>
 <% end -%>
 

--- a/kickstart/provision.erb
+++ b/kickstart/provision.erb
@@ -17,7 +17,7 @@ oses:
   os_major = @host.operatingsystem.major.to_i
   realm_compatible = (@host.operatingsystem.name == "Fedora" && os_major >= 20) || (rhel_compatible && os_major >= 7)
   # safemode renderer does not support unary negation
-  realm_incompatible = (@host.operatingsystem.name == "Fedora" && os_major < 20) || (rhel_compatible && os_major < 7) 
+  realm_incompatible = (@host.operatingsystem.name == "Fedora" && os_major < 20) || (rhel_compatible && os_major < 7)
   pm_set = @host.puppetmaster.empty? ? false : true
   puppet_enabled = pm_set || @host.params['force-puppet']
 %>
@@ -36,7 +36,7 @@ timezone <%= @host.params['time-zone'] || 'UTC' %>
 services --disabled autofs,gpm,sendmail,cups,iptables,ip6tables,auditd,arptables_jf,xfs,pcmcia,isdn,rawdevices,hpoj,bluetooth,openibd,avahi-daemon,avahi-dnsconfd,hidd,hplip,pcscd,restorecond,mcstrans,rhnsd,yum-updatesd
 <% end -%>
 
-<% if realm_compatible && @host.otp && @host.realm -%>
+<% if realm_compatible && @host.respond_to?(:otp) && @host.otp && @host.realm -%>
 realm join --one-time-password='<%= @host.otp %>' <%= @host.realm %>
 <% end -%>
 
@@ -113,7 +113,7 @@ echo "updating system time"
 /usr/sbin/ntpdate -sub <%= @host.params['ntp-server'] || '0.fedora.pool.ntp.org' %>
 /usr/sbin/hwclock --systohc
 
-<% if realm_incompatible && @host.otp && @host.realm && @host.realm.realm_type == "FreeIPA" -%>
+<% if realm_incompatible && @host.respond_to?(:otp) && @host.otp && @host.realm && @host.realm.realm_type == "FreeIPA" -%>
 <%= snippet "freeipa_register" %>
 <% end -%>
 

--- a/kickstart/provision_rhel.erb
+++ b/kickstart/provision_rhel.erb
@@ -25,7 +25,7 @@ firewall --<%= os_major >= 6 ? 'service=' : '' %>ssh
 authconfig --useshadow --passalgo=sha256 --kickstart
 timezone <%= @host.params['time-zone'] || 'UTC' %>
 
-<% if os_major >= 7 && @host.otp && @host.realm -%>
+<% if os_major >= 7 && @host.respond_to?(:otp) && @host.otp && @host.realm -%>
 realm join --one-time-password=<%= @host.otp %> <%= @host.realm %>
 <% end -%>
 


### PR DESCRIPTION
Pointed out on foreman-users that Foreman 1.4 doesn't understand what `@host.otp` is.  This seems to work in safemode for me.
