### PR TITLE
Update redhat_register.erb

### DIFF
--- a/snippets/redhat_register.erb
+++ b/snippets/redhat_register.erb
@@ -22,6 +22,8 @@ name: redhat_register
 #   subscription_manager_host = <hostname> (hostname of SAM/Katello
 #                                           installation, if using SAM)
 #
+#   subscription_manager_host_type = <hostname> (Type of host, SAM or Katello)
+#
 #   subscription_manager_org = <org name> (organization name, if using
 #                                          SAM/Katello)
 #
@@ -106,7 +108,12 @@ name: redhat_register
     subscription-manager repos --list > /dev/null
     <%= enabled_repos if enabled_repos %>
   <% elsif @host.params['activation_key'] %>
-    rpm -Uvh <%= @host.params['subscription_manager_host'] %>/pub/candlepin-cert-consumer-latest.noarch.rpm
+    <% host_type = @host.params['subscription_manager_host_type'] || 'SAM' %>
+   <% if host_type == "Katello" %>
+    rpm -Uvh http://<%= @host.params['subscription_manager_host'] %>/pub/katello-ca-consumer-latest.noarch.rpm
+   <% else %>
+    rpm -Uvh http://<%= @host.params['subscription_manager_host'] %>/pub/candlepin-cert-consumer-latest.noarch.rpm
+   <% end %>
     subscription-manager register --org="<%= @host.params['subscription_manager_org'] %>" --activationkey="<%= @host.params['activation_key'] %>"
     # workaround for RHEL 6.4 bug https://bugzilla.redhat.com/show_bug.cgi?id=1008016
     subscription-manager repos --list > /dev/null


### PR DESCRIPTION
Change to support default Katello cert in addition to SAM cert (locations are different). Default to SAM as subscription_manager_host. If user wants to use Katello they would need to set subscription_manager_host_type = "Katello" and subscription_manager_host = $FQDN
