### PR TITLE
Saltstack client support for RH and SUSE OSes

### DIFF
--- a/autoyast/provision.erb
+++ b/autoyast/provision.erb
@@ -7,6 +7,7 @@ name: AutoYaST default
   # safemode renderer does not support unary negation
   pm_set = @host.puppetmaster.empty? ? false : true
   puppet_enabled = pm_set || @host.params['force-puppet']
+  salt_enabled = @host.params['salt_master'] ? true : false
 %>
 <!DOCTYPE profile>
 <profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
@@ -58,6 +59,9 @@ name: AutoYaST default
 <% if puppet_enabled %>
       <package>puppet</package>
 <% end -%>
+<% if salt_enabled %>
+      <package>salt-minion</package>
+<% end -%>
     </packages>
   </software>
   <users config:type="list">
@@ -100,6 +104,14 @@ then
 fi
 /usr/bin/puppet agent --config /etc/puppet/puppet.conf -o --tags no_such_tag <%= @host.puppetmaster.blank? ? '' : "--server #{@host.puppetmaster}" %> --no-daemonize
 /sbin/chkconfig puppet on -f
+<% end -%>
+
+<% if salt_enabled %>
+cat > /etc/salt/minion << EOF
+<%= snippet 'saltstack_minion' %>
+EOF
+# Setup salt-minion to run on system reboot
+chkconfig salt-minion on
 <% end -%>
 
 /usr/bin/curl -o /dev/null -k '<%= foreman_url %>'

--- a/autoyast/provision_sles.erb
+++ b/autoyast/provision_sles.erb
@@ -9,6 +9,7 @@ oses:
   # safemode renderer does not support unary negation
   pm_set = @host.puppetmaster.empty? ? false : true
   puppet_enabled = pm_set || @host.params['force-puppet']
+  salt_enabled = @host.params['salt_master'] ? true : false
 %>
 <!DOCTYPE profile>
 <profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
@@ -61,6 +62,9 @@ oses:
       <package>puppet</package>
       <package>rubygem-ruby-augeas</package>
 <% end -%>
+<% if salt_enabled %>
+      <package>salt-minion</package>
+<% end -%>
     </packages>
   </software>
   <users config:type="list">
@@ -105,6 +109,14 @@ fi
 /sbin/chkconfig puppet on -f
 <% end -%>
 
+<% if salt_enabled %>
+cat > /etc/salt/minion << EOF
+<%= snippet 'saltstack_minion' %>
+EOF
+# Setup salt-minion to run on system reboot
+chkconfig salt-minion on
+<% end -%>
+
 /usr/bin/curl -o /dev/null -k '<%= foreman_url %>'
 
 rm /etc/resolv.conf
@@ -146,6 +158,28 @@ rm /etc/resolv.conf
             <all config:type="boolean">false</all>
             <keys config:type="list">
               <keyid>2ABFA143A0E46E11</keyid>
+            </keys>
+          </import_gpg_key>
+        </signature-handling>
+      </listentry>
+<% end -%>
+<% if salt_enabled %>
+      <listentry>
+        <media_url><![CDATA[http://download.opensuse.org/repositories/devel:languages:python/SLE_<%= @host.operatingsystem.major %>_SP<%= @host.operatingsystem.minor %>/]]></media_url>
+        <name>devel_languages_python</name>
+        <product>devel_languages_python</product>
+        <product_dir>/</product_dir>
+        <signature-handling>
+          <accept_non_trusted_gpg_key>
+            <all config:type="boolean">false</all>
+            <keys config:type="list">
+              <keyid>27163A4EEDF0D733</keyid>
+            </keys>
+          </accept_non_trusted_gpg_key>
+          <import_gpg_key>
+            <all config:type="boolean">false</all>
+            <keys config:type="list">
+              <keyid>27163A4EEDF0D733</keyid>
             </keys>
           </import_gpg_key>
         </signature-handling>

--- a/kickstart/provision.erb
+++ b/kickstart/provision.erb
@@ -20,6 +20,7 @@ oses:
   pm_set = @host.puppetmaster.empty? ? false : true
   proxy_string = @host.params['http-proxy'] ? " --proxy=http://#{@host.params['http-proxy']}:#{@host.params['http-proxy-port']}" : ''
   puppet_enabled = pm_set || @host.params['force-puppet']
+  salt_enabled = @host.params['salt_master'] ? true : false
   section_end = (rhel_compatible && os_major <= 5) ? '' : '%end'
 %>
 install
@@ -85,6 +86,9 @@ puppet
 puppetlabs-release
 <% end -%>
 <% end -%>
+<% if salt_enabled %>
+salt-minion
+<% end -%>
 <%= section_end -%>
 
 <% if @dynamic -%>
@@ -131,6 +135,14 @@ EOF
 /sbin/chkconfig --level 345 puppet on
 
 /usr/bin/puppet agent --config /etc/puppet/puppet.conf -o --tags no_such_tag <%= @host.puppetmaster.blank? ? '' : "--server #{@host.puppetmaster}" %> --no-daemonize
+<% end -%>
+
+<% if salt_enabled %>
+cat > /etc/salt/minion << EOF
+<%= snippet 'saltstack_minion' %>
+EOF
+# Setup salt-minion to run on system reboot
+/sbin/chkconfig --level 345 salt-minion on
 <% end -%>
 
 sync

--- a/kickstart/provision_rhel.erb
+++ b/kickstart/provision_rhel.erb
@@ -13,6 +13,7 @@ oses:
   pm_set = @host.puppetmaster.empty? ? false : true
   proxy_string = @host.params['http-proxy'] ? " --proxy=http://#{@host.params['http-proxy']}:#{@host.params['http-proxy-port']}" : ''
   puppet_enabled = pm_set || @host.params['force-puppet']
+  salt_enabled = @host.params['salt_master'] ? true : false
   section_end = os_major <= 5 ? '' : '%end'
 %>
 install
@@ -69,6 +70,9 @@ puppet
 puppetlabs-release
 <% end -%>
 <% end -%>
+<% if salt_enabled %>
+salt-minion
+<% end -%>
 <%= section_end -%>
 
 <% if @dynamic -%>
@@ -120,6 +124,14 @@ EOF
 /sbin/chkconfig --level 345 puppet on
 
 /usr/bin/puppet agent --config /etc/puppet/puppet.conf -o --tags no_such_tag <%= @host.puppetmaster.blank? ? '' : "--server #{@host.puppetmaster}" %> --no-daemonize
+<% end -%>
+
+<% if salt_enabled %>
+cat > /etc/salt/minion << EOF
+<%= snippet 'saltstack_minion' %>
+EOF
+# Setup salt-minion to run on system reboot
+/sbin/chkconfig --level 345 salt-minion on
 <% end -%>
 
 sync


### PR DESCRIPTION
I tested this with CentOS 6.5 and SLES 11SP3.

For RH based OSes the package is coming from EPEL, for SLES from the repo described in http://docs.saltstack.com/en/latest/topics/installation/suse.html

Fedora and OpenSUSE already have it in their base repos.
