### PR TITLE
fixes #6799 - Workaround for domainname service on RHEL 7 (BZ1071969)

### DIFF
--- a/snippets/freeipa_register.erb
+++ b/snippets/freeipa_register.erb
@@ -120,9 +120,17 @@ sed -i -e "s/services = .*/\0, sudo/" /etc/sssd/sssd.conf
 
   if [[ $(rpm -qa systemd | wc -l) -gt 0 ]];
   then
-    domain_service=`ls /usr/lib/systemd/system/*-domainname.service | rev | cut -d'/' -f 1 | rev`
-    systemctl start $domain_service
-    systemctl enable $domain_service
+    domain_service=/usr/lib/systemd/system/*-domainname.service
+
+    # Workaround for BZ1071969 on RHEL 7.0
+    grep -q "DefaultDependencies=no" $domain_service
+    if [[ $? -ne 0 ]]
+    then
+        sed -i -e "s/\[Unit\]/\[Unit\]\nDefaultDependencies=no/" $domain_service
+    fi
+
+    systemctl start $(basename $domain_service)
+    systemctl enable $(basename $domain_service)
   fi
 <% else -%>
   sed -i -e '/^exit /d' /etc/rc.local


### PR DESCRIPTION
rhel-domainname.service creates a cycle on system boot up.  Fix is in Fedora, but won't make it until RHEL 7.1.  This is a workaround.
