### PR TITLE
fixes #6363 - make hostgroup provisioning work

### DIFF
--- a/kickstart/finish.erb
+++ b/kickstart/finish.erb
@@ -17,6 +17,7 @@ oses:
   os_major = @host.operatingsystem.major.to_i
   pm_set = @host.puppetmaster.empty? ? false : true
   puppet_enabled = pm_set || @host.params['force-puppet']
+  host_provision = @provisioning_type == "host" || @provisioning_type.nil?
 %>
 
 <% if rhel_compatible -%>
@@ -39,7 +40,7 @@ echo "updating system time"
 /usr/sbin/ntpdate -sub <%= @host.params['ntp-server'] || '0.fedora.pool.ntp.org' %>
 /usr/sbin/hwclock --systohc
 
-<% if @host.info["parameters"]["realm"] && @host.otp && @host.realm && @host.realm.realm_type == "FreeIPA" -%>
+<% if host_provision && @host.otp && @host.realm && @host.realm.realm_type == "FreeIPA" -%>
 <%= snippet "freeipa_register" %>
 <% end -%>
 

--- a/kickstart/provision.erb
+++ b/kickstart/provision.erb
@@ -22,6 +22,7 @@ oses:
   puppet_enabled = pm_set || @host.params['force-puppet']
   salt_enabled = @host.params['salt_master'] ? true : false
   section_end = (rhel_compatible && os_major <= 5) ? '' : '%end'
+  host_provision = @provisioning_type == "host" || @provisioning_type.nil?
 %>
 install
 <%= @mediapath %><%= proxy_string %>
@@ -38,7 +39,7 @@ timezone --utc <%= @host.params['time-zone'] || 'UTC' %>
 services --disabled gpm,sendmail,cups,pcmcia,isdn,rawdevices,hpoj,bluetooth,openibd,avahi-daemon,avahi-dnsconfd,hidd,hplip,pcscd
 <% end -%>
 
-<% if realm_compatible && @host.info["parameters"]["realm"] && @host.otp && @host.realm && @host.realm.realm_type == "Active Directory" -%>
+<% if realm_compatible && host_provision && @host.otp && @host.realm && @host.realm.realm_type == "Active Directory" -%>
 realm join --one-time-password='<%= @host.otp %>' <%= @host.realm %>
 <% end -%>
 
@@ -120,7 +121,7 @@ echo "updating system time"
 /usr/sbin/ntpdate -sub <%= @host.params['ntp-server'] || '0.fedora.pool.ntp.org' %>
 /usr/sbin/hwclock --systohc
 
-<% if @host.info["parameters"]["realm"] && @host.otp && @host.realm && @host.realm.realm_type == "FreeIPA" -%>
+<% if host_provision && @host.otp && @host.realm && @host.realm.realm_type == "FreeIPA" -%>
 <%= snippet "freeipa_register" %>
 <% end -%>
 
@@ -151,10 +152,11 @@ salt-call --no-color --grains >/dev/null
 
 sync
 
+<% if host_provision -%>
 # Inform the build system that we are done.
 echo "Informing Foreman that we are built"
 wget -q -O /dev/null --no-check-certificate <%= foreman_url %>
-# Sleeping an hour for debug
+<% end -%>
 ) 2>&1 | tee /root/install.post.log
 exit 0
 

--- a/kickstart/provision_rhel.erb
+++ b/kickstart/provision_rhel.erb
@@ -15,6 +15,7 @@ oses:
   puppet_enabled = pm_set || @host.params['force-puppet']
   salt_enabled = @host.params['salt_master'] ? true : false
   section_end = os_major <= 5 ? '' : '%end'
+  host_provision = @provisioning_type == "host" || @provisioning_type.nil?
 %>
 install
 <%= @mediapath %><%= proxy_string %>
@@ -28,7 +29,7 @@ firewall --<%= os_major >= 6 ? 'service=' : '' %>ssh
 authconfig --useshadow --passalgo=sha256 --kickstart
 timezone --utc <%= @host.params['time-zone'] || 'UTC' %>
 
-<% if os_major >= 7 && @host.info["parameters"]["realm"] && @host.otp && @host.realm && @host.realm.realm_type == "Active Directory" -%>
+<% if os_major >= 7 && host_provision && @host.otp && @host.realm && @host.realm.realm_type == "Active Directory" -%>
 realm join --one-time-password=<%= @host.otp %> <%= @host.realm %>
 <% end -%>
 
@@ -101,7 +102,7 @@ echo "updating system time"
 
 <%= snippet 'redhat_register' %>
 
-<% if @host.info["parameters"]["realm"] && @host.otp && @host.realm && @host.realm.realm_type == "FreeIPA" -%>
+<% if host_provision && @host.otp && @host.realm && @host.realm.realm_type == "FreeIPA" -%>
 <%= snippet "freeipa_register" %>
 <% end -%>
 
@@ -135,10 +136,11 @@ salt-call --no-color --grains >/dev/null
 
 sync
 
+<% if host_provision -%>
 # Inform the build system that we are done.
 echo "Informing Foreman that we are built"
 wget -q -O /dev/null --no-check-certificate <%= foreman_url %>
-# Sleeping an hour for debug
+<% end -%>
 ) 2>&1 | tee /root/install.post.log
 exit 0
 

--- a/preseed/finish.erb
+++ b/preseed/finish.erb
@@ -13,6 +13,7 @@ oses:
   pm_set = @host.puppetmaster.empty? ? false : true
   puppet_enabled = pm_set || @host.params['force-puppet']
   salt_enabled = @host.params['salt_master'] ? true : false
+  host_provision = @provisioning_type == "host" || @provisioning_type.nil?
 %>
 <% if puppet_enabled %>
 cat > /etc/puppet/puppet.conf << EOF
@@ -27,7 +28,7 @@ fi
 /usr/bin/puppet agent --config /etc/puppet/puppet.conf --onetime --tags no_such_tag <%= @host.puppetmaster.blank? ? '' : "--server #{@host.puppetmaster}" %> --no-daemonize
 <% end -%>
 
-<% if @host.info["parameters"]["realm"] && @host.otp && @host.realm && @host.realm.realm_type == "FreeIPA" -%>
+<% if host_provision && @host.otp && @host.realm && @host.realm.realm_type == "FreeIPA" -%>
 <%= snippet 'freeipa_register' %>
 <% end -%>
 
@@ -39,4 +40,6 @@ EOF
 salt-call --no-color --grains >/dev/null
 <% end -%>
 
+<% if host_provision -%>
 /usr/bin/wget --no-proxy --quiet --output-document=/dev/null --no-check-certificate <%= foreman_url %>
+<% end -%>

--- a/snippets/puppet.conf.erb
+++ b/snippets/puppet.conf.erb
@@ -19,6 +19,6 @@ report          = true
 ignoreschedules = true
 daemon          = false
 ca_server       = <%= @host.puppet_ca_server %>
-certname        = <%= @host.certname %>
+certname        = <%= @host.respond_to?(:certname) ? @host.certname : "$HOSTNAME" %>
 environment     = <%= @host.environment %>
 server          = <%= @host.puppetmaster %>


### PR DESCRIPTION
Requires  https://github.com/theforeman/foreman/pull/1634 in order to have the latest version of SafeMode with fixed respond_to?

Note: This breaks Foreman < 1.5.3, but needs to be done to fix host group provisioning.
