### PR TITLE
fixes #6861 - properly detect host group provisioning in the templates

### DIFF
--- a/kickstart/provision.erb
+++ b/kickstart/provision.erb
@@ -151,10 +151,11 @@ salt-call --no-color --grains >/dev/null
 
 sync
 
+<% if @provisioning_type.nil? || @provisioning_type == 'host' -%>
 # Inform the build system that we are done.
 echo "Informing Foreman that we are built"
 wget -q -O /dev/null --no-check-certificate <%= foreman_url %>
-# Sleeping an hour for debug
+<% end -%>
 ) 2>&1 | tee /root/install.post.log
 exit 0
 

--- a/kickstart/provision_rhel.erb
+++ b/kickstart/provision_rhel.erb
@@ -135,10 +135,11 @@ salt-call --no-color --grains >/dev/null
 
 sync
 
+<% if @provisioning_type.nil? || @provisioning_type == 'host' -%>
 # Inform the build system that we are done.
 echo "Informing Foreman that we are built"
 wget -q -O /dev/null --no-check-certificate <%= foreman_url %>
-# Sleeping an hour for debug
+<% end -%>
 ) 2>&1 | tee /root/install.post.log
 exit 0
 

--- a/preseed/finish.erb
+++ b/preseed/finish.erb
@@ -39,4 +39,6 @@ EOF
 salt-call --no-color --grains >/dev/null
 <% end -%>
 
+<% if @provisioning_type.nil? || @provisioning_type == 'host' -%>
 /usr/bin/wget --no-proxy --quiet --output-document=/dev/null --no-check-certificate <%= foreman_url %>
+<% end -%>

--- a/snippets/puppet.conf.erb
+++ b/snippets/puppet.conf.erb
@@ -19,6 +19,6 @@ report          = true
 ignoreschedules = true
 daemon          = false
 ca_server       = <%= @host.puppet_ca_server %>
-certname        = <%= @host.certname %>
+certname        = <%= @host.respond_to?(:certname) ? @host.certname : "$HOSTNAME" %>
 environment     = <%= @host.environment %>
 server          = <%= @host.puppetmaster %>


### PR DESCRIPTION
Needs https://github.com/theforeman/foreman/pull/1637, but should be backwards compatible w/ older versions too.
