### PR TITLE
Remove Puppet from RHEL %packages list

### DIFF
--- a/kickstart/provision_rhel.erb
+++ b/kickstart/provision_rhel.erb
@@ -64,11 +64,8 @@ ntp
 wget
 @Core
 epel-release
-<% if puppet_enabled %>
-puppet
-<% if @host.params['enable-puppetlabs-repo'] && @host.params['enable-puppetlabs-repo'] == 'true' -%>
+<% if puppet_enabled && @host.params['enable-puppetlabs-repo'] && @host.params['enable-puppetlabs-repo'] == 'true' -%>
 puppetlabs-release
-<% end -%>
 <% end -%>
 <% if salt_enabled %>
 salt-minion


### PR DESCRIPTION
With RHEL, it doesn't make sense to install Puppet during the main section
of the installation as the optional repo isn't available.  Users either get
an error about missing deps, or a partially installed package.
