### PR TITLE
Remove --ignoremissing from %packages to prevent partial package installs

### DIFF
--- a/kickstart/provision.erb
+++ b/kickstart/provision.erb
@@ -73,7 +73,7 @@ bootloader --location=mbr --append="nofb quiet splash=quiet" <%= grub_pass %>
 text
 reboot
 
-%packages --ignoremissing
+%packages
 yum
 dhclient
 ntp

--- a/kickstart/provision_rhel.erb
+++ b/kickstart/provision_rhel.erb
@@ -57,7 +57,7 @@ key --skip
 text
 reboot
 
-%packages --ignoremissing
+%packages
 yum
 dhclient
 ntp


### PR DESCRIPTION
We've seen some via #theforeman where packages are getting installed without dependencies and other oddities.  I don't think there's anything in the default list that isn't shipped.
