### PR TITLE
Start salt-minion during provisioning in order to get signed keys

### DIFF
--- a/autoyast/provision.erb
+++ b/autoyast/provision.erb
@@ -112,6 +112,8 @@ cat > /etc/salt/minion << EOF
 EOF
 # Setup salt-minion to run on system reboot
 chkconfig salt-minion on
+# Running salt-call to trigger key signing
+salt-call --no-color --grains >/dev/null
 <% end -%>
 
 /usr/bin/curl -o /dev/null -k '<%= foreman_url %>'

--- a/autoyast/provision_sles.erb
+++ b/autoyast/provision_sles.erb
@@ -115,6 +115,8 @@ cat > /etc/salt/minion << EOF
 EOF
 # Setup salt-minion to run on system reboot
 chkconfig salt-minion on
+# Running salt-call to trigger key signing
+salt-call --no-color --grains >/dev/null
 <% end -%>
 
 /usr/bin/curl -o /dev/null -k '<%= foreman_url %>'

--- a/freebsd/finish_FreeBSD_mfsBSD.erb
+++ b/freebsd/finish_FreeBSD_mfsBSD.erb
@@ -44,5 +44,7 @@ cat > /usr/local/etc/salt/minion << EOF
 EOF
 echo 'salt_minion_enable="YES"' >>/etc/rc.conf
 echo 'salt_minion_paths="/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin"' >>/etc/rc.conf
+# Running salt-call to trigger key signing
+/usr/local/bin/salt-call --no-color --grains >/dev/null
 <% end -%>
 exit 0

--- a/kickstart/provision.erb
+++ b/kickstart/provision.erb
@@ -143,6 +143,8 @@ cat > /etc/salt/minion << EOF
 EOF
 # Setup salt-minion to run on system reboot
 /sbin/chkconfig --level 345 salt-minion on
+# Running salt-call to trigger key signing
+salt-call --no-color --grains >/dev/null
 <% end -%>
 
 sync

--- a/kickstart/provision_rhel.erb
+++ b/kickstart/provision_rhel.erb
@@ -129,6 +129,8 @@ cat > /etc/salt/minion << EOF
 EOF
 # Setup salt-minion to run on system reboot
 /sbin/chkconfig --level 345 salt-minion on
+# Running salt-call to trigger key signing
+salt-call --no-color --grains >/dev/null
 <% end -%>
 
 sync

--- a/preseed/finish.erb
+++ b/preseed/finish.erb
@@ -35,6 +35,8 @@ fi
 cat > /etc/salt/minion << EOF
 <%= snippet 'saltstack_minion' %>
 EOF
+# Running salt-call to trigger key signing
+salt-call --no-color --grains >/dev/null
 <% end -%>
 
 /usr/bin/wget --no-proxy --quiet --output-document=/dev/null --no-check-certificate <%= foreman_url %>


### PR DESCRIPTION
Need to run 'service salt-minion start' while the autosign record from foreman_salt exists.
