### PR TITLE
FreeBSD: do not hardcode disk device

### DIFF
--- a/freebsd/provision_FreeBSD_mfsBSD.erb
+++ b/freebsd/provision_FreeBSD_mfsBSD.erb
@@ -4,8 +4,13 @@ name: FreeBSD (mfsBSD) provision
 oses:
 - FreeBSD 10.0
 %>
-/root/bin/destroygeom -d <%= @host.params['install-disk'] || 'ada0' %> || exit 1
-/root/bin/zfsinstall -d <%= @host.params['install-disk'] || 'ada0' %> -s 2G -u <%= @mediapath %> || exit 1
+# Get the disk layout, and the first disk connected to the system
+disk_layout=`/sbin/sysctl -n kern.disks | /usr/bin/sed 's/cd[0-9]//g'`
+first_disk="`echo ${disk_layout##*[1-9]} | /usr/bin/cut -d' ' -f1`"
+test -z "$first_disk" || echo "First disk: $first_disk"
+
+/root/bin/destroygeom -d <%= @host.params['install-disk'] || '$first_disk' %> || exit 1
+/root/bin/zfsinstall -d <%= @host.params['install-disk'] || '$first_disk' %> -s 2G -u <%= @mediapath %> || exit 1
 
 cp /etc/resolv.conf /mnt/etc/resolv.conf
 mount -t devfs devfs /mnt/dev


### PR DESCRIPTION
Replace the hardcoded disk device 'ada0' with a more dynamic approach.

It's based on an idea [by Amitabh Kant](http://www.amitabhkant.com/partition-automation-in-bsdinstall-auto-script-in-freebsd/), so credits go to him.
