### PR TITLE
Distinguish between CentOS and Fedora when activating puppet agent

### DIFF
--- a/kickstart/finish.erb
+++ b/kickstart/finish.erb
@@ -54,7 +54,9 @@ EOF
 
 # Setup puppet to run on system reboot
 <% if @host.operatingsystem.name == 'Fedora' -%>
-/usr/bin/systemctl enable puppetagent
+puppet_unit=puppet
+/usr/bin/systemctl list-unit-files | grep -q puppetagent && puppet_unit=puppetagent
+/usr/bin/systemctl enable ${puppet_unit}
 <% else -%>
 /sbin/chkconfig --level 345 puppet on
 <% end -%>


### PR DESCRIPTION
This is needed because on Fedora, the service is called puppetagent
