### PR TITLE
rhbz#1140057 don't run auto-attach if pool is specified

### DIFF
--- a/snippets/redhat_register.erb
+++ b/snippets/redhat_register.erb
@@ -130,9 +130,11 @@ name: redhat_register
     <% end %>
   <% end %>
   <% if @host.params['subscription_manager_username'] && @host.params['subscription_manager_password'] %>
-    subscription-manager register --username="<%= @host.params['subscription_manager_username'] %>" --password="<%= @host.params['subscription_manager_password'] %>" --auto-attach
     <% if @host.params['subscription_manager_pool'] %>
+      subscription-manager register --username="<%= @host.params['subscription_manager_username'] %>" --password="<%= @host.params['subscription_manager_password'] %>"
       subscription-manager attach --pool="<%= @host.params['subscription_manager_pool'] %>"
+    <% else %>
+      subscription-manager register --username="<%= @host.params['subscription_manager_username'] %>" --password="<%= @host.params['subscription_manager_password'] %>" --auto-attach
     <% end %>
     # workaround for RHEL 6.4 bug https://bugzilla.redhat.com/show_bug.cgi?id=1008016
     subscription-manager repos --list > /dev/null


### PR DESCRIPTION
currently we always run auto-attach with subscription-manager.
we should only run it if we don't have a pool.

Signed-off-by: Mike Burns <mburns@redhat.com>