### PR TITLE
Add epel url for RHEL 7

### DIFF
--- a/snippets/epel.erb
+++ b/snippets/epel.erb
@@ -13,6 +13,8 @@ name: epel
   epel_url.gsub!("$os",'5-4')
   when '6'
   epel_url.gsub!("$os",'6-8')
+  when '7'
+  epel_url = "http://dl.fedoraproject.org/pub/epel/7/$arch/e/epel-release-7-2.noarch.rpm"
   else
   ''
   end


### PR DESCRIPTION
This simply adds the new epel url for RHEL 7. See  #114.
