### PR TITLE
Preseed: Backslashes don't need to be escaped

### DIFF
--- a/preseed/disklayout_lvm.erb
+++ b/preseed/disklayout_lvm.erb
@@ -16,47 +16,47 @@ d-i partman-md/device_remove_md boolean true
 d-i partman-lvm/confirm boolean true
 d-i partman-lvm/confirm_nooverwrite boolean true
 
-d-i partman-auto/init_automatically_partition \\
+d-i partman-auto/init_automatically_partition \
 	select Guided - use entire disk and set up LVM
 
 d-i partman-auto-lvm/guided_size string max
 d-i partman-auto-lvm/new_vg_name string vg00
 
-d-i partman-auto/expert_recipe string                         \\
-      boot-root ::                                            \\
-              64 128 128 ext3                                 \\
-                      $primary{ } $bootable{ }                \\
-                      method{ format } format{ }              \\
-                      use_filesystem{ } filesystem{ ext4 }    \\
-                      mountpoint{ /boot }                     \\
-              .                                               \\
-              128 512 200% linux-swap                         \\
-                      method{ swap } format{ }                \\
-              .                                               \\
-              512 512 512 ext3                                \\
-                      method{ format } format{ } $lvmok{ }    \\
-                      use_filesystem{ } filesystem{ ext4 }    \\
-                      mountpoint{ / }                         \\
-              .                                               \\
-              256 256 256 ext3                                \\
-                      method{ format } format{ } $lvmok{ }    \\
-                      use_filesystem{ } filesystem{ ext4 }    \\
-                      mountpoint{ /home }                     \\
-              .                                               \\
-              256 512 512 ext3                                \\
-                      method{ format } format{ } $lvmok{ }    \\
-                      use_filesystem{ } filesystem{ ext4 }    \\
-                      mountpoint{ /tmp }                      \\
-              .                                               \\
-              2048 4096 4096 ext3                             \\
-                      method{ format } format{ } $lvmok{ }    \\
-                      use_filesystem{ } filesystem{ ext4 }    \\
-                      mountpoint{ /usr }                      \\
-              .                                               \\
-              2048 4096 -1 ext3                               \\
-                      method{ format } format{ } $lvmok{ }    \\
-                      use_filesystem{ } filesystem{ ext4 }    \\
-                      mountpoint{ /var }                      \\
+d-i partman-auto/expert_recipe string                         \
+      boot-root ::                                            \
+              64 128 128 ext3                                 \
+                      $primary{ } $bootable{ }                \
+                      method{ format } format{ }              \
+                      use_filesystem{ } filesystem{ ext4 }    \
+                      mountpoint{ /boot }                     \
+              .                                               \
+              128 512 200% linux-swap                         \
+                      method{ swap } format{ }                \
+              .                                               \
+              512 512 512 ext3                                \
+                      method{ format } format{ } $lvmok{ }    \
+                      use_filesystem{ } filesystem{ ext4 }    \
+                      mountpoint{ / }                         \
+              .                                               \
+              256 256 256 ext3                                \
+                      method{ format } format{ } $lvmok{ }    \
+                      use_filesystem{ } filesystem{ ext4 }    \
+                      mountpoint{ /home }                     \
+              .                                               \
+              256 512 512 ext3                                \
+                      method{ format } format{ } $lvmok{ }    \
+                      use_filesystem{ } filesystem{ ext4 }    \
+                      mountpoint{ /tmp }                      \
+              .                                               \
+              2048 4096 4096 ext3                             \
+                      method{ format } format{ } $lvmok{ }    \
+                      use_filesystem{ } filesystem{ ext4 }    \
+                      mountpoint{ /usr }                      \
+              .                                               \
+              2048 4096 -1 ext3                               \
+                      method{ format } format{ } $lvmok{ }    \
+                      use_filesystem{ } filesystem{ ext4 }    \
+                      mountpoint{ /var }                      \
               .
 
 d-i partman/default_filesystem string ext4


### PR DESCRIPTION
As the anti-slashes are not evaluated during import.

See also: https://www.debian.org/releases/stable/i386/apbs04.html.en#preseed-partman
