### PR TITLE
Adapted template to support new puppet service

### DIFF
--- a/kickstart/provision.erb
+++ b/kickstart/provision.erb
@@ -134,6 +134,9 @@ cat > /etc/puppet/puppet.conf << EOF
 EOF
 
 # Setup puppet to run on system reboot
+test -x /usr/bin/systemctl && \
+    /usr/bin/systemctl list-unit-files | grep -q ^puppetagent\.service && \
+    /usr/bin/systemctl enable puppetagent.service || \
 /sbin/chkconfig --level 345 puppet on
 
 /usr/bin/puppet agent --config /etc/puppet/puppet.conf -o --tags no_such_tag <%= @host.puppetmaster.blank? ? '' : "--server #{@host.puppetmaster}" %> --no-daemonize

--- a/kickstart/provision_rhel.erb
+++ b/kickstart/provision_rhel.erb
@@ -118,6 +118,9 @@ cat > /etc/puppet/puppet.conf << EOF
 EOF
 
 # Setup puppet to run on system reboot
+test -x /usr/bin/systemctl && \
+    /usr/bin/systemctl list-unit-files | grep -q ^puppetagent\.service && \
+    /usr/bin/systemctl enable puppetagent.service || \
 /sbin/chkconfig --level 345 puppet on
 
 /usr/bin/puppet agent --config /etc/puppet/puppet.conf -o --tags no_such_tag <%= @host.puppetmaster.blank? ? '' : "--server #{@host.puppetmaster}" %> --no-daemonize


### PR DESCRIPTION
Newer Puppet packegs do not seem to create the 'puppet' service on
systemd-enabled distributions. A 'puppetagent.service' unit file is
created instead. This patche fixes the default kickstart provisionig
template to support this configuration.