### PR TITLE
Debian: Ensure keymap is set from lang

### DIFF
--- a/preseed/PXELinux.erb
+++ b/preseed/PXELinux.erb
@@ -10,7 +10,7 @@ oses:
 %>
 
 <% if @host.operatingsystem.name == 'Debian' -%>
-<% keyboard_params = "auto=true console-keymaps-at/keymap=us keymap=us domain=#{@host.domain}" -%>
+<% keyboard_params = "auto=true domain=#{@host.domain}" -%>
 <% else -%>
 <% keyboard_params = 'console-setup/ask_detect=false console-setup/layout=USA console-setup/variant=USA keyboard-configuration/layoutcode=us localechooser/translation/warn-light=true localechooser/translation/warn-severe=true' -%>
 <% end -%>

--- a/preseed/iPXE.erb
+++ b/preseed/iPXE.erb
@@ -8,7 +8,7 @@ oses:
 - Ubuntu 12.04
 %>
 <% if @host.operatingsystem.name == 'Debian' -%>
-<% keyboard_params = "auto=true console-keymaps-at/keymap=us keymap=us domain=#{@host.domain}" -%>
+<% keyboard_params = "auto=true domain=#{@host.domain}" -%>
 <% else -%>
 <% keyboard_params = 'console-setup/ask_detect=false console-setup/layout=USA console-setup/variant=USA keyboard-configuration/layoutcode=us' -%>
 <% end -%>

--- a/preseed/provision.erb
+++ b/preseed/provision.erb
@@ -17,7 +17,11 @@ oses:
 %>
 # Locale
 d-i debian-installer/locale string <%= @host.params['lang'] || 'en_US' %>
-# country and keyboard settings are automatic
+# country and keyboard settings are automatic. Keep them ...
+# ... for wheezy and newer:
+d-i keyboard-configuration/xkb-keymap seen true
+# ... for squeeze and older:
+d-i console-keymaps-at/keymap seen true
 
 <% if @static -%>
 # Static network configuration.


### PR DESCRIPTION
Since jessie, keymap kernel parameter takes precedence over auto-detection.

We remove keymap related parameters from kernel parameters,
and let keyboard-configuration do it's job.

Tested on:
- squeeze
- wheezy
- jessie

This is a follow-up for #119.
