### PR TITLE
scrap format=xml from autoyast PXELinux template

### DIFF
--- a/autoyast/PXELinux.erb
+++ b/autoyast/PXELinux.erb
@@ -5,4 +5,4 @@ name: AutoYaST default PXELinux
 default linux
 label linux
 kernel <%= @kernel %>
-append initrd=<%= @initrd %> ramdisk_size=65536 install=<%= media_path %> autoyast=<%= foreman_url('provision') + '?format=xml' %> textmode=1
+append initrd=<%= @initrd %> ramdisk_size=65536 install=<%= media_path %> autoyast=<%= foreman_url('provision') %> textmode=1


### PR DESCRIPTION
As a followup to theforeman/foreman#1881 remove the appendix completely. I couldn't find any reference about that in the SuSE docs and even versions as old as OpenSuSE 11.4 are installing flawlessy without it. It was included in the very first commit in Foreman that added SuSE support and the history is unclear...
