### PR TITLE
Added templates for CoreOS support - feature 7652

### DIFF
--- a/coreos/PXELinux.erb
+++ b/coreos/PXELinux.erb
@@ -1,0 +1,10 @@
+<%#
+kind: PXELinux
+name: CoreOS PXELinux
+oses:
+- CoreOS
+%>
+default coreos
+label coreos
+  kernel <%= @kernel %>
+  append initrd=<%= @initrd %> cloud-config-url=<%= foreman_url('provision')%>

--- a/coreos/disklayout_CoreOS.erb
+++ b/coreos/disklayout_CoreOS.erb
@@ -1,0 +1,7 @@
+<%#
+kind: ptable
+name: CoreOS default fake
+oses:
+- CoreOS
+%>
+# Not supported with coreos-install

--- a/coreos/provision.erb
+++ b/coreos/provision.erb
@@ -1,0 +1,31 @@
+#cloud-config
+<%#
+kind: provision
+name: CoreOS provision
+oses:
+- CoreOS
+%>
+coreos:
+  units:
+    - name: coreos-bootstrap.service
+      runtime: no
+      command: start
+      content: |
+        [Unit]
+        Description=Install coreos to disk
+        [Service]
+        ExecStart=/bin/bash -c "/usr/bin/coreos-install -C  <%= @host.operatingsystem.release_name %> -d <%= @host.params['install-disk'] || '/dev/sda' %> -c /home/core/cloud-config.yml && wget -q -O /dev/null --no-check-certificate <%= foreman_url %> && reboot"
+        [X-Fleet]
+        X-Conflicts=coreos-bootstrap.service
+<% if @host.params['ssh_authorized_keys'] -%>
+ssh_authorized_keys:
+<% @host.params['ssh_authorized_keys'].split(',').map(&:strip).each do |ssh_key| -%>
+  - "<%= ssh_key %>"
+<% end -%>
+<% end -%>
+write_files:
+  - content: |
+      <%= snippet 'coreos_cloudconfig' %>
+    path: /home/core/cloud-config.yml
+    permissions: '0600'
+    owner: core:core

--- a/snippets/coreos_cloudconfig.erb
+++ b/snippets/coreos_cloudconfig.erb
@@ -1,0 +1,46 @@
+#cloud-config
+<%#
+kind: snippet
+name: coreos_cloudconfig
+%>
+      coreos:
+        etcd:
+<% if @host.params['etcd_discovery_url'] -%>
+          discovery: <%= @host.params['etcd_discovery_url'] %>
+<% end -%>
+          addr: <%= @host.ip %>:4001
+          peer-addr: <%= @host.ip %>:7001
+        units:
+          - name: etcd.service
+            command: start
+          - name: fleet.service
+            command: start
+          - name: docker-tcp.socket
+            command: start
+            enable: yes
+            content: |
+              [Unit]
+              Description=Docker Socket for the API
+              
+              [Socket]
+              ListenStream=2375
+              BindIPv6Only=both
+              Service=docker.service
+              
+              [Install]
+              WantedBy=sockets.target
+          - name: enable-docker-tcp.service
+            command: start
+            content: |
+              [Unit]
+              Description=Enable the Docker Socket for the API
+              
+              [Service]
+              Type=oneshot
+              ExecStart=/usr/bin/systemctl enable docker-tcp.socket
+<% if @host.params['ssh_authorized_keys'] -%>
+      ssh_authorized_keys:
+  <% @host.params['ssh_authorized_keys'].split(',').map(&:strip).each do |ssh_key| -%>
+      - "<%= ssh_key %>"
+  <% end -%>
+<% end -%>


### PR DESCRIPTION
Community Templates for CoreOS in addition to https://github.com/theforeman/foreman/pull/1890 (Foreman CoreOS support).

By default the templates assume that coreOS should be installed to /dev/sda. You can overwrite the behaviour by setting the install-disk host parameter:

```
install-disk: /dev/vda
```

Optionally you can provision ssh keys using the ssh_authorized_keys host parameter:

```
ssh_authorized_keys: ssh-rsa AAAAB...== root@somehost.local
```

In order to provision a discovery token for etcd you can set the etcd_discovery_url host parameter:

```
etcd_discovery_url: https://discovery.etcd.io/059fb72d2e690b847...
```
