### PR TITLE
update autoyast for SLES 12 and OpenSuSE 13

### DIFF
--- a/autoyast/provision.erb
+++ b/autoyast/provision.erb
@@ -52,16 +52,29 @@ name: AutoYaST default
   <%= @host.diskLayout %>
   <runlevel>
     <default>3</default>
+    <services config:type="list">
+      <service>
+        <service_name>sshd</service_name>
+        <service_status>enable</service_status>
+      </service>
+    </services>
   </runlevel>
   <software>
     <base>default</base>
+    <patterns config:type="list">
+      <pattern>base</pattern>
+      <pattern>enhanced_base</pattern>
+      <pattern>sw_management</pattern>
+      <pattern>yast2_basis</pattern>
+    </patterns>
     <packages config:type="list">
-<% if puppet_enabled %>
+<% if puppet_enabled -%>
       <package>puppet</package>
 <% end -%>
 <% if salt_enabled %>
       <package>salt-minion</package>
 <% end -%>
+      <package>yast2-runlevel</package>
     </packages>
   </software>
   <users config:type="list">
@@ -94,7 +107,7 @@ cp /etc/resolv.conf /mnt/etc
         <interpreter>shell</interpreter>
         <notification>Setting up Puppet / Foreman ...</notification>
         <source><![CDATA[
-<% if puppet_enabled %>
+<% if puppet_enabled -%>
           cat > /etc/puppet/puppet.conf << EOF
 <%= snippet 'puppet.conf' -%>
 EOF

--- a/autoyast/provision_sles.erb
+++ b/autoyast/provision_sles.erb
@@ -4,12 +4,16 @@ kind: provision
 name: AutoYaST SLES default
 oses:
 - SLES 11
+- SLES 12
 %>
 <%
   # safemode renderer does not support unary negation
+  os_major = @host.operatingsystem.major.to_i
+  os_minor = @host.operatingsystem.minor.to_i
   pm_set = @host.puppetmaster.empty? ? false : true
   puppet_enabled = pm_set || @host.params['force-puppet']
   salt_enabled = @host.params['salt_master'] ? true : false
+  sles_minor_string = (os_minor == 0) ? '' : "_SP#{os_minor}"
 %>
 <!DOCTYPE profile>
 <profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
@@ -54,15 +58,26 @@ oses:
   <%= @host.diskLayout %>
   <runlevel>
     <default>3</default>
+    <services config:type="list">
+      <service>
+        <service_name>sshd</service_name>
+        <service_status>enable</service_status>
+      </service>
+    </services>
   </runlevel>
   <software>
-    <base>default</base>
+    <patterns config:type="list">
+      <pattern>Minimal</pattern>
+    </patterns>
     <packages config:type="list">
-<% if puppet_enabled %>
+      <package>less</package>
+      <package>openssh</package>
+      <package>vim</package>
+<% if puppet_enabled -%>
       <package>puppet</package>
       <package>rubygem-ruby-augeas</package>
 <% end -%>
-<% if salt_enabled %>
+<% if salt_enabled -%>
       <package>salt-minion</package>
 <% end -%>
     </packages>
@@ -97,8 +112,9 @@ cp /etc/resolv.conf /mnt/etc
         <interpreter>shell</interpreter>
         <notification>Setting up Puppet / Foreman ...</notification>
         <source><![CDATA[
-<% if puppet_enabled %>
-          cat > /etc/puppet/puppet.conf << EOF
+/bin/hostname <%= @host.name %>
+<% if puppet_enabled -%>
+cat > /etc/puppet/puppet.conf << EOF
 <%= snippet 'puppet.conf' -%>
 EOF
 if [ -f "/etc/sysconfig/puppet" ]
@@ -136,16 +152,9 @@ rm /etc/resolv.conf
   </timezone>
   <add-on>
     <add_on_products config:type="list">
-<% if puppet_enabled %>
+<% if puppet_enabled -%>
       <listentry>
-<!-- you have to update the next line with the actual URL of your SDK -->
-        <media_url>http://<your_server_here>/iso/suse/SDK/<%= @host.operatingsystem.major %>.<%= @host.operatingsystem.minor %>/<%= @host.architecture %>/</media_url>
-        <product>SuSE-Linux-SDK</product>
-        <product_dir>/</product_dir>
-        <name>SuSE-Linux-SDK</name>
-      </listentry>
-      <listentry>
-        <media_url><![CDATA[http://download.opensuse.org/repositories/systemsmanagement:/puppet/SLE_<%= @host.operatingsystem.major %>_SP<%= @host.operatingsystem.minor %>/]]></media_url>
+        <media_url><![CDATA[http://download.opensuse.org/repositories/systemsmanagement:/puppet/SLE_<%= os_major %><%= sles_minor_string %>/]]></media_url>
         <name>systemsmanagement_puppet</name>
         <product>systemsmanagement_puppet</product>
         <product_dir>/</product_dir>
@@ -164,8 +173,9 @@ rm /etc/resolv.conf
           </import_gpg_key>
         </signature-handling>
       </listentry>
+<% if os_major < 12 -%>
       <listentry>
-        <media_url><![CDATA[http://download.opensuse.org/repositories/devel:languages:ruby:backports/SLE_<%= @host.operatingsystem.major %>_SP<%= @host.operatingsystem.minor %>/]]></media_url>
+        <media_url><![CDATA[http://download.opensuse.org/repositories/devel:languages:ruby:backports/SLE_<%= os_major %><%= sles_minor_string %>/]]></media_url>
         <name>devel_languages_ruby_backports</name>
         <product>devel_languages_ruby_backports</product>
         <product_dir>/</product_dir>
@@ -183,11 +193,19 @@ rm /etc/resolv.conf
             </keys>
           </import_gpg_key>
         </signature-handling>
-        </listentry>
+      </listentry>
+      <listentry>
+<!-- you have to update the next line with the actual URL of your SDK -->
+        <media_url>http://<your_server_here>/iso/suse/SDK/<%= os_major %>.<%= os_minor %>/<%= @host.architecture %>/</media_url>
+        <product>SuSE-Linux-SDK</product>
+        <product_dir>/</product_dir>
+        <name>SuSE-Linux-SDK</name>
+      </listentry>
+<% end -%>
 <% end -%>
 <% if salt_enabled %>
       <listentry>
-        <media_url><![CDATA[http://download.opensuse.org/repositories/devel:languages:python/SLE_<%= @host.operatingsystem.major %>_SP<%= @host.operatingsystem.minor %>/]]></media_url>
+        <media_url><![CDATA[http://download.opensuse.org/repositories/devel:languages:python/SLE_<%= os_major %><%= sles_minor_string %>/]]></media_url>
         <name>devel_languages_python</name>
         <product>devel_languages_python</product>
         <product_dir>/</product_dir>


### PR DESCRIPTION
some updates to the autoyast templates, tested and working with:
- SLES 11 SP3
- SLES 12
- OpenSuSE 13.1
- OpenSuSE 13.2

On OpenSuSE 11.4 (really EOL now: http://www.rosenauer.org/blog/2014/09/27/opensuse-11-4-has-reached-end-of-evergreen-support/) installing with Puppet seems to trigger a bug and one has to press "OK" one time.

On OpenSuSE 12.3 (EOL 2015-01-04), bug 801878 (https://bugzilla.novell.com/show_bug.cgi?id=801878) is triggered, I'm not sure if that should taken into account or not...

@mattiasgiese @lazyfrosch - comments welcome!
