### PR TITLE
change puppet package for SLES

### DIFF
--- a/autoyast/provision_sles.erb
+++ b/autoyast/provision_sles.erb
@@ -74,8 +74,7 @@ oses:
       <package>openssh</package>
       <package>vim</package>
 <% if puppet_enabled -%>
-      <package>puppet</package>
-      <package>rubygem-ruby-augeas</package>
+      <package>rubygem-puppet</package>
 <% end -%>
 <% if salt_enabled -%>
       <package>salt-minion</package>


### PR DESCRIPTION
The package name in the systemsmanagemnt:puppet repository got changed (similar to https://bugzilla.opensuse.org/show_bug.cgi?id=908212).

I'd like to continue installing the Augeas rubygem together with Puppet in our templates to be able to use Augeas statements in Puppet manifests out of the box also on SLES. Other Puppet packages (from Puppetlabs, Debian/Ubuntu, EPEL) depend on that gem, so this functionality is just there on other distros.