### PR TITLE
Remove force from ipa-client-install

### DIFF
--- a/snippets/freeipa_register.erb
+++ b/snippets/freeipa_register.erb
@@ -56,7 +56,7 @@ freeipa_ssh="--no-ssh"
 freeipa_opts="<%= @host.params['freeipa_opts'] %>"
 <% end -%>
 
-/usr/sbin/ipa-client-install -w '<%= @host.otp %>' --realm=<%= @host.realm %> -f -U $freeipa_mkhomedir $freeipa_opts $freeipa_server $freeipa_ssh
+/usr/sbin/ipa-client-install -w '<%= @host.otp %>' --realm=<%= @host.realm %> -U $freeipa_mkhomedir $freeipa_opts $freeipa_server $freeipa_ssh
 
 ##
 ## Automounter


### PR DESCRIPTION
Specifying '-f' for ipa-client-install causes /etc/krb5.conf to be misconfigured by not configuring dns_lookup_kdc.