### PR TITLE
set grub-installer/bootdev in preseed

### DIFF
--- a/preseed/PXELinux.erb
+++ b/preseed/PXELinux.erb
@@ -4,9 +4,11 @@ name: Preseed default PXELinux
 oses:
 - Debian 6.0
 - Debian 7.
+- Debian 8.
 - Ubuntu 10.04
 - Ubuntu 12.04
 - Ubuntu 13.04
+- Ubuntu 14.04
 %>
 
 <% if @host.operatingsystem.name == 'Debian' -%>

--- a/preseed/README.md
+++ b/preseed/README.md
@@ -5,8 +5,10 @@ Tested on:
 * Ubuntu 10.04 (lucid)
 * Ubuntu 12.04 (precise)
 * Ubuntu 13.04 (raring)
+* Ubuntu 14.04 (trusty)
 * Debian 6.0 (Squeeze)
 * Debian 7 (Wheezy)
+* Debian 8 (Jessie)
 
 # Host Parameters
 

--- a/preseed/disklayout.erb
+++ b/preseed/disklayout.erb
@@ -4,9 +4,11 @@ name: Preseed default
 oses:
 - Debian 6.0
 - Debian 7.
+- Debian 8.
 - Ubuntu 10.04
 - Ubuntu 12.04
 - Ubuntu 13.04
+- Ubuntu 14.04
 %>
 
 <% if @host.params['install-disk'] -%>

--- a/preseed/disklayout_lvm.erb
+++ b/preseed/disklayout_lvm.erb
@@ -4,11 +4,17 @@ name: Preseed custom LVM
 oses:
 - Debian 6.0
 - Debian 7.
+- Debian 8.
 - Ubuntu 10.04
 - Ubuntu 12.04
 - Ubuntu 13.04
+- Ubuntu 14.04
 %>
-d-i partman-auto/disk string /dev/sda
+<% if @host.params['install-disk'] -%>
+d-i partman-auto/disk string <%= @host.params['install-disk'] %>
+<% else -%>
+d-i partman-auto/disk string /dev/sda /dev/vda
+<% end -%>
 d-i partman-auto/method string lvm
 
 d-i partman-lvm/device_remove_lvm boolean true

--- a/preseed/finish.erb
+++ b/preseed/finish.erb
@@ -4,9 +4,11 @@ name: Preseed default finish
 oses:
 - Debian 6.0
 - Debian 7.
+- Debian 8.
 - Ubuntu 10.04
 - Ubuntu 12.04
 - Ubuntu 13.04
+- Ubuntu 14.04
 %>
 <%
   # safemode renderer does not support unary negation

--- a/preseed/iPXE.erb
+++ b/preseed/iPXE.erb
@@ -5,7 +5,9 @@ name: Preseed default iPXE
 oses:
 - Debian 6.0
 - Debian 7.
+- Debian 8.
 - Ubuntu 12.04
+- Ubuntu 14.04
 %>
 <% if @host.operatingsystem.name == 'Debian' -%>
 <% keyboard_params = "auto=true domain=#{@host.domain}" -%>

--- a/preseed/provision.erb
+++ b/preseed/provision.erb
@@ -4,9 +4,11 @@ name: Preseed default
 oses:
 - Debian 6.0
 - Debian 7.
+- Debian 8.
 - Ubuntu 10.04
 - Ubuntu 12.04
 - Ubuntu 13.04
+- Ubuntu 14.04
 %>
 <%
   # safemode renderer does not support unary negation
@@ -137,7 +139,11 @@ popularity-contest popularity-contest/participate boolean false
 #grub-pc grub-pc/timeout string 10
 d-i grub-installer/only_debian boolean true
 d-i grub-installer/with_other_os boolean true
-
+<% if @host.params['install-disk'] -%>
+d-i grub-installer/bootdev string <%= @host.params['install-disk'] %>
+<% else -%>
+d-i grub-installer/bootdev string default
+<% end -%>
 d-i finish-install/reboot_in_progress note
 
 d-i preseed/late_command string wget -Y off <%= @static ? "'#{foreman_url('finish')}&static=true'" : foreman_url('finish') %> -O /target/tmp/finish.sh && in-target chmod +x /tmp/finish.sh && in-target /tmp/finish.sh

--- a/preseed/userdata.erb
+++ b/preseed/userdata.erb
@@ -4,7 +4,9 @@ name: Preseed default user data
 oses:
 - Debian 6.0
 - Debian 7.
+- Debian 8.
 - Ubuntu 12.04
+- Ubuntu 14.04
 %>
 #!/bin/bash
 


### PR DESCRIPTION
see Debian bugs 712907 and 759737 for reference, required for Debian/jessie
closes GH-135

As already found out in earlier PRs, older installers will ignore unknown lines, so this will do no harm.
Maybe @lazyfrosch and @sathieu could review?