### PR TITLE
Corrected coreos-bootstrap.service

### DIFF
--- a/coreos/provision.erb
+++ b/coreos/provision.erb
@@ -14,7 +14,7 @@ coreos:
         [Unit]
         Description=Install coreos to disk
         [Service]
-        ExecStart=/bin/bash -c "/usr/bin/coreos-install -C  <%= @host.operatingsystem.release_name %> -d <%= @host.params['install-disk'] || '/dev/sda' %> -c /home/core/cloud-config.yml> <% if @host.operatingsystem.major >= "557" -%>-b <%= @mediapath %><% end -%>  && wget -q -O /dev/null --no-check-certificate <%= foreman_url %> && reboot"
+        ExecStart=/bin/bash -c "/usr/bin/coreos-install -C  <%= @host.operatingsystem.release_name %> -d <%= @host.params['install-disk'] || '/dev/sda' %> -c /home/core/cloud-config.yml <% if @host.operatingsystem.major >= "557" -%>-b <%= @mediapath %><% end -%>  && wget -q -O /dev/null --no-check-certificate <%= foreman_url %> && reboot"
         [X-Fleet]
         X-Conflicts=coreos-bootstrap.service
 <% if @host.params['ssh_authorized_keys'] -%>


### PR DESCRIPTION
There was a '>' in the coreos-bootstrap.service which prevents the install script to use the passed base-url.