### PR TITLE
Add built-in support for chef

### DIFF
--- a/kickstart/provision.erb
+++ b/kickstart/provision.erb
@@ -21,6 +21,7 @@ oses:
   proxy_string = @host.params['http-proxy'] ? " --proxy=http://#{@host.params['http-proxy']}:#{@host.params['http-proxy-port']}" : ''
   puppet_enabled = pm_set || @host.params['force-puppet'] && @host.params['force-puppet'] == 'true'
   salt_enabled = @host.params['salt_master'] ? true : false
+  chef_enabled = @host.respond_to?(:chef_proxy) && @host.chef_proxy
   section_end = (rhel_compatible && os_major <= 5) ? '' : '%end'
 %>
 install
@@ -142,6 +143,11 @@ echo "updating system time"
 
 # update all the base packages from the updates repository
 yum -t -y -e 0 update
+
+<% if chef_enabled %>
+echo "Bootstraping chef"
+<%= respond_to?(:chef_bootstrap) ? chef_bootstrap(@host) : snippet_if_exists("chef-client omnibus bootstrap") %>
+<% end%>
 
 <% if puppet_enabled %>
 echo "Configuring puppet"

--- a/preseed/finish.erb
+++ b/preseed/finish.erb
@@ -15,6 +15,7 @@ oses:
   pm_set = @host.puppetmaster.empty? ? false : true
   puppet_enabled = pm_set || @host.params['force-puppet'] && @host.params['force-puppet'] == 'true'
   salt_enabled = @host.params['salt_master'] ? true : false
+  chef_enabled = @host.respond_to?(:chef_proxy) && @host.chef_proxy
 %>
 <% if @static -%>
 # host and domain name need setting as these values may have come from dhcp if pxe booting
@@ -47,5 +48,9 @@ EOF
 # Running salt-call to trigger key signing
 salt-call --no-color --grains >/dev/null
 <% end -%>
+
+<% if chef_enabled %>
+<%= respond_to?(:chef_bootstrap) ? chef_bootstrap(@host) : snippet_if_exists("chef-client omnibus bootstrap") %>
+<% end%>
 
 /usr/bin/wget --no-proxy --quiet --output-document=/dev/null --no-check-certificate <%= foreman_url %>


### PR DESCRIPTION
It's not ideal to add code required for plugins to work, but there's probably no better way of doing this right now. It would be really awesome if we could get this into 1.8, Chef integration could be finally installed easily and could compete to other cfgmgmt tools.