### PR TITLE
Refs #9615 - Use parent interface MAC for virtual interfaces

### DIFF
--- a/snippets/kickstart_networking_setup.erb
+++ b/snippets/kickstart_networking_setup.erb
@@ -67,7 +67,7 @@ EOF
 <% dhcp = !subnet.nil? && subnet.dhcp_boot_mode? -%>
 
 # <%= interface.identifier %> interface
-real=`ip -o link | grep <%= interface.mac -%> | awk '{print $2;}' | sed s/:$//`
+real=`ip -o link | grep <%= interface.respond_to?(:inheriting_mac) ? interface.inheriting_mac : interface.mac -%> | awk '{print $2;}' | sed s/:$//`
 <% if virtual -%>
 real=`echo <%= interface.identifier -%> | sed s/<%= interface.attached_to -%>/$real/`
 <% end -%>


### PR DESCRIPTION
This relies on https://github.com/theforeman/foreman/pull/2222, I use respond_to? as I don't know whether this will get into 1.8. If it will, we can simplify it to use just `interface.inheriting_mac` without any condition.