### PR TITLE
use correct provisioning URL for FreeBSD

### DIFF
--- a/freebsd/PXELinux_FreeBSD_mfsBSD.erb
+++ b/freebsd/PXELinux_FreeBSD_mfsBSD.erb
@@ -4,7 +4,7 @@ name: FreeBSD (mfsBSD) PXELinux
 oses:
 - FreeBSD 10.0
 %>
-# foreman_url=<%= foreman_url %>
+# foreman_url=<%= foreman_url('provision') %>
 DEFAULT freebsd
 
 LABEL freebsd


### PR DESCRIPTION
found that after upgrading to 1.8, I wonder why it worked before :)