### PR TITLE
Remove empty space in 'userdata' preseed script

### DIFF
--- a/preseed/userdata.erb
+++ b/preseed/userdata.erb
@@ -7,7 +7,7 @@ oses:
 - Debian 8.
 - Ubuntu 12.04
 - Ubuntu 14.04
-%>
+-%>
 #!/bin/bash
 
 <%# Cloud instances frequently have incorrect hosts data %>


### PR DESCRIPTION
Cloud-init/nix is particular about the magic string being on the first line. The erb script that is prior to the magic line is adding an empty line to the rendered template.
- Add suppress new line upon erb rendering of the function '<% %>' prior to the magic line.

closes GH-165