### PR TITLE
puppet.conf: don't set ca_server value if host property is empty

### DIFF
--- a/snippets/puppet.conf.erb
+++ b/snippets/puppet.conf.erb
@@ -18,7 +18,9 @@ pluginsync      = true
 report          = true
 ignoreschedules = true
 daemon          = false
+<%- if @host.puppet_ca_server.strip -%>
 ca_server       = <%= @host.puppet_ca_server %>
+<%- end -%>
 certname        = <%= @host.certname %>
 environment     = <%= @host.environment %>
 server          = <%= @host.puppetmaster %>


### PR DESCRIPTION
This is required in cases where Puppet should implicitly use the specified (puppetmaster) server as CA server. Specifying a Puppet CA server in Foreman results in errors if that server is only proxying calls to the CA. Pending a solution in Foreman itself, changing this provision template so that no ca_server is specified (leading to the "server" being used as CA) would at least get rid of errors.

Additionally, I believe that this behavior is more intuitive when leaving the "Puppet CA" field in the Foreman host editor empty, rather than this resulting in an empty value in puppet.conf which leads to an error.