### PR TITLE
refs #9782 - SUSE: usage of mediapath in PXELinux

### DIFF
--- a/autoyast/PXELinux.erb
+++ b/autoyast/PXELinux.erb
@@ -6,4 +6,4 @@ DEFAULT linux
 
 LABEL linux
     KERNEL <%= @kernel %>
-    APPEND initrd=<%= @initrd %> ramdisk_size=65536 install=<%= media_path %> autoyast=<%= foreman_url('provision') %> textmode=1
+    APPEND initrd=<%= @initrd %> ramdisk_size=65536 install=<%= @host.os.medium_uri(@host) %> autoyast=<%= foreman_url('provision') %> textmode=1


### PR DESCRIPTION
Also see theforeman/foreman#2393.

If anybody wants to pour in their energy to workaround another SUSE specific oddity cleanly in Foreman core it would be very welcome, for now this hacky workaround should get most things going again.

@mattiasgiese, please test.