### PR TITLE
OpenSUSE 13.2 has no yast2-runlevel anymore

### DIFF
--- a/autoyast/provision.erb
+++ b/autoyast/provision.erb
@@ -4,6 +4,8 @@ kind: provision
 name: AutoYaST default
 %>
 <%
+  os_major = @host.operatingsystem.major.to_i
+  os_minor = @host.operatingsystem.minor.to_i
   # safemode renderer does not support unary negation
   pm_set = @host.puppetmaster.empty? ? false : true
   puppet_enabled = pm_set || @host.params['force-puppet'] && @host.params['force-puppet'] == 'true'
@@ -69,11 +71,13 @@ name: AutoYaST default
     </patterns>
     <packages config:type="list">
       <package>lsb-release</package>
+<% if ((os_minor < 2) && (os_major < 14)) -%>
       <package>yast2-runlevel</package>
+<% end -%>
 <% if puppet_enabled -%>
       <package>puppet</package>
 <% end -%>
-<% if salt_enabled %>
+<% if salt_enabled -%>
       <package>salt-minion</package>
 <% end -%>
     </packages>
@@ -108,8 +112,9 @@ cp /etc/resolv.conf /mnt/etc
         <interpreter>shell</interpreter>
         <notification>Setting up Puppet / Foreman ...</notification>
         <source><![CDATA[
+/bin/hostname <%= @host.name %>
 <% if puppet_enabled -%>
-          cat > /etc/puppet/puppet.conf << EOF
+cat > /etc/puppet/puppet.conf << EOF
 <%= snippet 'puppet.conf' -%>
 EOF
 if [ -f "/etc/sysconfig/puppet" ]

--- a/autoyast/provision_sles.erb
+++ b/autoyast/provision_sles.erb
@@ -7,9 +7,9 @@ oses:
 - SLES 12
 %>
 <%
-  # safemode renderer does not support unary negation
   os_major = @host.operatingsystem.major.to_i
   os_minor = @host.operatingsystem.minor.to_i
+  # safemode renderer does not support unary negation
   pm_set = @host.puppetmaster.empty? ? false : true
   puppet_enabled = pm_set || @host.params['force-puppet'] && @host.params['force-puppet'] == 'true'
   salt_enabled = @host.params['salt_master'] ? true : false
@@ -138,7 +138,7 @@ chkconfig salt-minion on
 # Running salt-call to trigger key signing
 salt-call --no-color --grains >/dev/null
 <% end -%>
-<% if spacewalk_enabled %>
+<% if spacewalk_enabled -%>
 <%= snippet 'redhat_register' %>
 <% end -%>
 
@@ -210,7 +210,7 @@ rm /etc/resolv.conf
       </listentry>
 <% end -%>
 <% end -%>
-<% if salt_enabled %>
+<% if salt_enabled -%>
       <listentry>
         <media_url><![CDATA[http://download.opensuse.org/repositories/devel:languages:python/SLE_<%= os_major %><%= sles_minor_string %>/]]></media_url>
         <name>devel_languages_python</name>
@@ -232,7 +232,7 @@ rm /etc/resolv.conf
         </signature-handling>
       </listentry>
 <% end -%>
-<% if spacewalk_enabled %>
+<% if spacewalk_enabled -%>
       <listentry>
         <media_url><![CDATA[http://download.opensuse.org/repositories/systemsmanagement:/spacewalk/SLE_<%= os_major %><%= sles_minor_string %>/]]></media_url>
         <name>systemsmanagement_spacewalk</name>


### PR DESCRIPTION
...while it's needed on <13.2 for sshd to really get started on the installed system.

See https://groups.google.com/d/msg/foreman-users/ZfCoAdhJc5I/lMpmab1LTmEJ for a successful testing result. Maybe @mattiasgiese or @lazyfrosch also could have a look?
