### PR TITLE
Initial support for NX-OS POAP

### DIFF
--- a/poap/README.md
+++ b/poap/README.md
@@ -1,0 +1,3 @@
+# Cisco NX-OS PowerOn Auto Provisioning (POAP) support
+
+More information is available here: http://projects.theforeman.org/issues/10526

--- a/poap/disklayout.erb
+++ b/poap/disklayout.erb
@@ -1,0 +1,7 @@
+<%#
+kind: ptable
+name: NX-OS default fake
+oses:
+- NX-OS
+%>
+# Not required for NX-OS POAP provisioning.

--- a/poap/provision.erb
+++ b/poap/provision.erb
@@ -1,0 +1,9 @@
+<%#
+kind: POAP
+name: NX-OS default POAP setup
+oses:
+- NX-OS
+%>
+# This template file is only a placeholder. Cisco provides sample Python
+# scripts for POAP, but they are only distributed through their support site.
+# You will need to provide your own POAP scripts or download one from Cisco.


### PR DESCRIPTION
This commit adds a partition table template needed for NX-OS POAP support under [foreman](https://github.com/theforeman/foreman). It is tied up to this [pull request](https://github.com/theforeman/foreman/pull/2464).
