### PR TITLE
Fixes #10935 - FreeIPA client registration with --server enabled fails.

### DIFF
--- a/snippets/freeipa_register.erb
+++ b/snippets/freeipa_register.erb
@@ -39,9 +39,10 @@ name: freeipa_register
 ##
 ## IPA Client Installation
 ##
-
 <% if @host.params['freeipa_server'] -%>
-freeipa_server="--server <%= @host.params['freeipa_server'] %>"
+<% domain = @host.params['freeipa_domain'] || @host.realm.name.downcase -%>
+
+freeipa_server="--server <%= @host.params['freeipa_server'] %> --domain <%=domain %>"
 <% end -%>
 
 <% unless @host.param_false? 'freeipa_mkhomedir' %>


### PR DESCRIPTION
I encountered errors while testing the FreeIPA integration module. The hosts were added to IPA, but never registered locally. I tracked it down to enabled --server option, which was supplied without the required --domain one, ending with ipa-client-install returning an error.

This patch adds freeipa_domain host parameter for --domain option, and adds --server only if it's present.
