### PR TITLE
FreeBSD: set hostname in chroot & use UTC for CMOS

### DIFF
--- a/freebsd/finish_FreeBSD_mfsBSD.erb
+++ b/freebsd/finish_FreeBSD_mfsBSD.erb
@@ -23,8 +23,8 @@ echo ifconfig_`ifconfig -l | cut -d ' ' -f 1`=DHCP >>/etc/rc.conf
 
 echo 'PermitRootLogin yes' >> /etc/ssh/sshd_config
 
+/bin/hostname <%= @host.name %>
 cp /usr/share/zoneinfo/<%= @host.params['time-zone'] || 'UTC' %> /etc/localtime
-touch /etc/wall_cmos_clock
 adjkerntz -a
 ntpdate <%= @host.params['ntp-server'] || '0.freebsd.pool.ntp.org' %>
 env ASSUME_ALWAYS_YES=YES pkg bootstrap


### PR DESCRIPTION
- somehow having the hostname explicitely set is required for newer releases (10.2-PRERELEASE in my tests), maybe also puppet behavour changed here, but it doesn't harm anyway
- removing /etc/wall_cmos_clock means, the time is stored in UTC in the CMOS clock, which is a good thing for UNIX systems
