### PR TITLE
Anaconda RHEL7 network options support

### DIFF
--- a/kickstart/PXELinux.erb
+++ b/kickstart/PXELinux.erb
@@ -36,13 +36,11 @@ DEFAULT linux
 
 LABEL linux
     KERNEL <%= @kernel %>
-    <% if @host.operatingsystem.name.match(/.*atomic.*/i) %>
+    <% if (@host.operatingsystem.name == 'Fedora' and @host.operatingsystem.major.to_i > 16) or (@host.operatingsystem.name != 'Fedora' and @host.operatingsystem.major.to_i >= 7) -%>
+    APPEND initrd=<%= @initrd %> inst.ks=<%= foreman_url('provision')%> inst.ks.sendmac <%= options %>
+    <% elsif @host.operatingsystem.name.match(/.*atomic.*/i) %>
     APPEND initrd=<%= @initrd %> ks=<%= foreman_url('provision') %> repo=<%= @host.operatingsystem.medium_uri(@host) %> ks.device=bootif network ks.sendmac <%= options %>
-    <% elsif @host.operatingsystem.name == 'Fedora' and @host.operatingsystem.major.to_i > 16 -%>
-    APPEND initrd=<%= @initrd %> ks=<%= foreman_url('provision')%> ks.device=bootif network ks.sendmac <%= options %>
-    <% elsif @host.operatingsystem.name != 'Fedora' and @host.operatingsystem.major.to_i >= 7 -%>
-    APPEND initrd=<%= @initrd %> ks=<%= foreman_url('provision')%> network ks.sendmac <%= options %>
     <% else -%>
-    APPEND initrd=<%= @initrd %> ks=<%= foreman_url('provision')%> ksdevice=bootif network kssendmac <%= options %>
+    APPEND initrd=<%= @initrd %> ks=<%= foreman_url('provision')%> kssendmac network <%= options %>
     <% end -%>
     IPAPPEND 2

--- a/kickstart/iPXE.erb
+++ b/kickstart/iPXE.erb
@@ -26,7 +26,11 @@ oses:
 <%# This template will not function with Safemode set to true.
     Please disable it in Settings > Provisioning               %>
 
+<% if (@host.operatingsystem.name == 'Fedora' and @host.operatingsystem.major.to_i > 16) or (@host.operatingsystem.name != 'Fedora' and @host.operatingsystem.major.to_i >= 7) -%>
+kernel <%= "#{@host.url_for_boot(:kernel)}" %> inst.ks=<%= foreman_url('provision')%><%= static %> bootif=<%= @host.mac %> inst.ks.sendmac ip=${netX/ip}::${netX/gateway}::${netX/netmask}:::none nameserver=${dns}
+<% else -%>
 kernel <%= "#{@host.url_for_boot(:kernel)}" %> ks=<%= foreman_url('provision')%><%= static %> ksdevice=<%= @host.mac %> network kssendmac ip=${netX/ip} netmask=${netX/netmask} gateway=${netX/gateway} dns=${dns}
+<% end -%>
 initrd <%= "#{@host.url_for_boot(:initrd)}" %>
 
 boot

--- a/pxe/PXELinux_default.erb
+++ b/pxe/PXELinux_default.erb
@@ -28,7 +28,7 @@ LABEL <%= "#{profile[:template]} - #{profile[:hostgroup]}" %>
      KERNEL <%= profile[:hostgroup].operatingsystem.kernel(profile[:hostgroup].architecture) %>
 <% case profile[:hostgroup].operatingsystem.pxe_type -%>
 <% when 'kickstart' -%>
-     APPEND initrd=<%= profile[:hostgroup].operatingsystem.initrd(profile[:hostgroup].architecture) %> ks=<%= default_template_url(profile[:template], profile[:hostgroup]) %> ksdevice=bootif network kssendmac
+     APPEND initrd=<%= profile[:hostgroup].operatingsystem.initrd(profile[:hostgroup].architecture) %> ks=<%= default_template_url(profile[:template], profile[:hostgroup]) %> ksdevice=bootif network kssendmac inst.ks.sendmac
 <% when 'preseed' -%>
      APPEND initrd=<%= profile[:hostgroup].operatingsystem.initrd(profile[:hostgroup].architecture) %> interface=auto url=<%= default_template_url(profile[:template], profile[:hostgroup]) %> ramdisk_size=10800 root=/dev/rd/0 rw auto hostname=unassigned-hostname locale=<%= profile[:hostgroup].params['lang'] || 'en_US' %> console-setup/ask_detect=false console-setup/layout=USA console-setup/variant=USA
 <% end -%>


### PR DESCRIPTION
It looks like we have missed new options introduced in RHEL7. The best
documentation for these can be found in

https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Installation_Guide/chap-anaconda-boot-options.html

when you scroll down to 20.1.1. Deprecated and Removed Boot Options.

This patch changes PXELinux and iPXE kickstart templates. In PXELinux we
already had some changes in this regard, but it was not correct. We had
"ks.sendmac" instead of correct "inst.ks.sendmac". This was introcuded in
b00e2b0b9013 by @witlessbird. Maybe this was valid for Fedora 16, but in RHEL7
the only supported one should be "inst.ks.sendmac". Other changes:
- inst.ks.sendmac the only supported option now
- ksdevice=bootif is now default and ignored
- new ip command for dracut which consolidate all static network options

For hostgroup provisioning I am just adding `inst.ks.sendmac` along with the
legacy `sendmac` command. This will issue warning in Anaconda log but it works.

Help me testing this on RHELs, CentOses and Fedoras.
