### PR TITLE
Blacklist option for Red Hat and Debian PXELinux

### DIFF
--- a/kickstart/PXELinux.erb
+++ b/kickstart/PXELinux.erb
@@ -16,15 +16,31 @@ oses:
 - RedHat 6
 - RedHat 7
 %>
+#
+# This file was deployed via '<%= @template_name %>' template
+#
+# Supported host/hostgroup parameters:
+#
+# blacklist = module1, module2
+#   Blacklisted kernel modules
+#
+<%
+  options = []
+  if @host.params['blacklist']
+    options << "modprobe.blacklist=" + @host.params['blacklist'].gsub(' ', '')
+  end
+  options = options.join(' ')
+-%>
+
 DEFAULT linux
 
 LABEL linux
     KERNEL <%= @kernel %>
     <% if @host.operatingsystem.name == 'Fedora' and @host.operatingsystem.major.to_i > 16 -%>
-    APPEND initrd=<%= @initrd %> ks=<%= foreman_url('provision')%> ks.device=bootif network ks.sendmac
+    APPEND initrd=<%= @initrd %> ks=<%= foreman_url('provision')%> ks.device=bootif network ks.sendmac <%= options %>
     <% elsif @host.operatingsystem.name != 'Fedora' and @host.operatingsystem.major.to_i >= 7 -%>
-    APPEND initrd=<%= @initrd %> ks=<%= foreman_url('provision')%> network ks.sendmac
+    APPEND initrd=<%= @initrd %> ks=<%= foreman_url('provision')%> network ks.sendmac <%= options %>
     <% else -%>
-    APPEND initrd=<%= @initrd %> ks=<%= foreman_url('provision')%> ksdevice=bootif network kssendmac
+    APPEND initrd=<%= @initrd %> ks=<%= foreman_url('provision')%> ksdevice=bootif network kssendmac <%= options %>
     <% end -%>
     IPAPPEND 2

--- a/preseed/PXELinux.erb
+++ b/preseed/PXELinux.erb
@@ -10,15 +10,35 @@ oses:
 - Ubuntu 13.04
 - Ubuntu 14.04
 %>
+#
+# This file was deployed via '<%= @template_name %>' template
+#
+# Supported host/hostgroup parameters:
+#
+# blacklist = module1, module2
+#   Blacklisted kernel modules
+#
+# lang = en_US
+#   System locale
+#
+<%
+  options = []
+  if @host.params['blacklist']
+    options << @host.params['blacklist'].split(',').collect{|x| "#{x.strip}.blacklist=yes"}.join(' ')
+  end
+  if @host.operatingsystem.name == 'Debian'
+    options << "auto=true"
+    options << "domain=#{@host.domain}"
+  else
+    options << 'console-setup/ask_detect=false console-setup/layout=USA console-setup/variant=USA keyboard-configuration/layoutcode=us localechooser/translation/warn-light=true localechooser/translation/warn-severe=true'
+  end
+  options << (@host.params['lang'] || 'en_US')
+  options = options.join(' ')
+-%>
 
-<% if @host.operatingsystem.name == 'Debian' -%>
-<% keyboard_params = "auto=true domain=#{@host.domain}" -%>
-<% else -%>
-<% keyboard_params = 'console-setup/ask_detect=false console-setup/layout=USA console-setup/variant=USA keyboard-configuration/layoutcode=us localechooser/translation/warn-light=true localechooser/translation/warn-severe=true' -%>
-<% end -%>
 DEFAULT linux
 
 LABEL linux
     KERNEL <%= @kernel %>
-    APPEND initrd=<%= @initrd %> interface=auto url=<%= foreman_url('provision')%> ramdisk_size=10800 root=/dev/rd/0 rw auto hostname=<%= @host.name %> <%= keyboard_params %> locale=<%= @host.params['lang'] || 'en_US' %>
+    APPEND initrd=<%= @initrd %> interface=auto url=<%= foreman_url('provision')%> ramdisk_size=10800 root=/dev/rd/0 rw auto hostname=<%= @host.name %> <%= options %>
     IPAPPEND 2


### PR DESCRIPTION
This introduces new host param `blacklist` which renders for Red Hats and
Debian/Ubuntu. Also I have refactored Debian PXELinux template variables so
it's more consistent now.
