### PR TITLE
Salt master no longer returns true when set to 'false'

### DIFF
--- a/kickstart/provision.erb
+++ b/kickstart/provision.erb
@@ -35,7 +35,7 @@ This template accepts the following parameters:
   proxy_uri = @host.params['http-proxy'] ? "http://#{@host.params['http-proxy']}:#{@host.params['http-proxy-port']}" : nil
   proxy_string = proxy_uri ? " --proxy=#{proxy_uri}" : ''
   puppet_enabled = pm_set || @host.params['force-puppet'] && @host.params['force-puppet'] == 'true'
-  salt_enabled = @host.params['salt_master'] ? true : false
+  salt_enabled = @host.params['salt_master'] == 'true'
   chef_enabled = @host.respond_to?(:chef_proxy) && @host.chef_proxy
   section_end = (rhel_compatible && os_major <= 5) ? '' : '%end'
 %>


### PR DESCRIPTION
The current default template just checks for the existence of the parameter, not its value. When an user sets the 'salt_master' parameter to 'false', it's expected to not enable Salt in the host, however it'll enable it. I changed it to check if the value of the parameter is the string 'true' as we do with 'force-puppet' above.
