### PR TITLE
Use SaltStack repos

### DIFF
--- a/kickstart/finish.erb
+++ b/kickstart/finish.erb
@@ -21,6 +21,7 @@ service network restart
   rhel_compatible = @host.operatingsystem.family == 'Redhat' && @host.operatingsystem.name != 'Fedora'
   os_major = @host.operatingsystem.major.to_i
   pm_set = @host.puppetmaster.empty? ? false : true
+  salt_enabled = @host.params['salt_master'] ? true : false
   puppet_enabled = pm_set || @host.params['force-puppet'] && @host.params['force-puppet'] == 'true'
 %>
 
@@ -42,6 +43,27 @@ rpm -ivh http://yum.puppetlabs.com/puppetlabs-release-el-<%= os_major -%>.noarch
 <% end -%>
 <% end -%>
 yum -t -y -e 0 install puppet
+<% end -%>
+
+<% if salt_enabled %>
+<% if @host.params['enable-saltstack-repo'] && @host.params['enable-saltstack-repo'] == 'true' -%>
+cat > /etc/yum.repos.d/saltstack.repo <<EOF
+[saltstack-repo]
+name=SaltStack repo for RHEL/CentOS $releasever
+baseurl=https://repo.saltstack.com/yum/rhel$releasever
+enabled=1
+gpgcheck=1
+gpgkey=https://repo.saltstack.com/yum/rhel$releasever/SALTSTACK-GPG-KEY.pub
+EOF
+<% end -%>
+yum -t -y -e 0 install salt-minion
+cat > /etc/salt/minion << EOF
+<%= snippet 'saltstack_minion' %>
+EOF
+# Setup salt-minion to run on system reboot
+/sbin/chkconfig --level 345 salt-minion on
+# Running salt-call to trigger key signing
+salt-call --no-color --grains >/dev/null
 <% end -%>
 
 #update local time

--- a/kickstart/provision.erb
+++ b/kickstart/provision.erb
@@ -23,6 +23,7 @@ This template accepts the following parameters:
 - force-puppet: boolean (default=false)
 - enable-puppetlabs-repo: boolean (default=false)
 - salt_master: string (default=undef)
+- enable-saltsatck-repo: boolean (default=false)
 - ntp-server: string (default="0.fedora.pool.ntp.org")
 - bootloader-append: string (default="nofb quiet splash=quiet")
 %>
@@ -78,6 +79,9 @@ repo --name="EPEL" --mirrorlist=https://mirrors.fedoraproject.org/metalink?repo=
 <% if puppet_enabled && @host.params['enable-puppetlabs-repo'] && @host.params['enable-puppetlabs-repo'] == 'true' -%>
 repo --name=puppetlabs-products --baseurl=http://yum.puppetlabs.com/el/<%= @host.operatingsystem.major %>/products/<%= @host.architecture %><%= proxy_string %>
 repo --name=puppetlabs-deps --baseurl=http://yum.puppetlabs.com/el/<%= @host.operatingsystem.major %>/dependencies/<%= @host.architecture %><%= proxy_string %>
+<% end -%>
+<% if salt_enabled && @host.params['enable-saltstack-repo'] && @host.params['enable-saltstack-repo'] == 'true' -%>
+repo --name=saltstack-repo --baseurl=https://repo.saltstack.com/yum/rhel<%= @host.operatingsystem.major %><%= proxy_string %>
 <% end -%>
 <% end -%>
 

--- a/kickstart/provision_rhel.erb
+++ b/kickstart/provision_rhel.erb
@@ -18,6 +18,7 @@ This template accepts the following parameters:
 - force-puppet: boolean (default=false)
 - enable-puppetlabs-repo: boolean (default=false)
 - salt_master: string (default=undef)
+- enable-saltsatck-repo: boolean (default=false)
 - ntp-server: string (default="0.fedora.pool.ntp.org")
 - bootloader-append: string (default="nofb quiet splash=quiet")
 %>
@@ -62,6 +63,9 @@ repo --name="EPEL" --mirrorlist=https://mirrors.fedoraproject.org/metalink?repo=
 <% if puppet_enabled && @host.params['enable-puppetlabs-repo'] && @host.params['enable-puppetlabs-repo'] == 'true' -%>
 repo --name=puppetlabs-products --baseurl=http://yum.puppetlabs.com/el/<%= @host.operatingsystem.major %>/products/<%= @host.architecture %><%= proxy_string %>
 repo --name=puppetlabs-deps --baseurl=http://yum.puppetlabs.com/el/<%= @host.operatingsystem.major %>/dependencies/<%= @host.architecture %><%= proxy_string %>
+<% end -%>
+<% if salt_enabled && @host.params['enable-saltstack-repo'] && @host.params['enable-saltstack-repo'] == 'true' -%>
+repo --name=saltstack-repo --baseurl=https://repo.saltstack.com/yum/rhel<%= @host.operatingsystem.major %><%= proxy_string %>
 <% end -%>
 <% end -%>
 


### PR DESCRIPTION
Starting with 2015.8.0, SaltStack will provide their own repositories.

I'll update for Debian later, as Ubuntu is not yet available.  https://groups.google.com/forum/#!topic/salt-users/hteT6sDi39w
