### PR TITLE
Fixes #11440 - Network bonding is not working properly when provisioning CentOS/RHEL servers because the default gateway is not set

### DIFF
--- a/snippets/kickstart_networking_setup.erb
+++ b/snippets/kickstart_networking_setup.erb
@@ -50,7 +50,7 @@ DEVICE="$real"
 ONBOOT=yes
 PEERDNS=no
 PEERROUTES=no
-DEFROUTE=<%= bond.primary? ? 'yes' : 'no' -%>
+DEFROUTE="<%= bond.primary ? 'yes' : 'no' -%>"
 TYPE=Bond
 BONDING_OPTS="<%= bond.bond_options -%> mode=<%= bond.mode -%>"
 BONDING_MASTER=yes


### PR DESCRIPTION
Hello.

The previous commit related to this issue (http://projects.theforeman.org/issues/11440) was wrong: https://github.com/theforeman/community-templates/pull/201.

I modified the file and tested it with real hardware and this commit should fix it.

Regards

PetrR
