### PR TITLE
Don't specify Debian and Ubuntu version explicitely

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,12 @@ determine information abut the template. The metadata is read until the first no
 line, and contains, the template name, template kind, and any appropriate OS
 associations. For example:
 
-    #kind: provision
-    #name: My Preseed
+    #kind: user_data
+    #name: My Userdata
     #oses:
-    #- Debian 6.0
-    #- Debian 7.
+    # - CentOS 7
+    # - Debian
+    # - Ubuntu
 
 Because all the data is contained in the metadata, filenames are arbitrary, however,
 for consistency we ask that they be grouped appropriately, and end in `.erb`.

--- a/cloudinit/userdata_cloudinit.erb
+++ b/cloudinit/userdata_cloudinit.erb
@@ -13,11 +13,8 @@ oses:
 - Fedora 20
 - Fedora 21
 - Fedora 22
-- Debian 6.0
-- Debian 7.
-- Ubuntu 10.04
-- Ubuntu 12.04
-- Ubuntu 13.04
+- Debian
+- Ubuntu
 -%>
 #cloud-config
 hostname: <%= @host.shortname %>

--- a/preseed/PXELinux.erb
+++ b/preseed/PXELinux.erb
@@ -2,13 +2,8 @@
 kind: PXELinux
 name: Preseed default PXELinux
 oses:
-- Debian 6.0
-- Debian 7.
-- Debian 8.
-- Ubuntu 10.04
-- Ubuntu 12.04
-- Ubuntu 13.04
-- Ubuntu 14.04
+- Debian
+- Ubuntu
 %>
 #
 # This file was deployed via '<%= @template_name %>' template

--- a/preseed/disklayout.erb
+++ b/preseed/disklayout.erb
@@ -2,13 +2,8 @@
 kind: ptable
 name: Preseed default
 oses:
-- Debian 6.0
-- Debian 7.
-- Debian 8.
-- Ubuntu 10.04
-- Ubuntu 12.04
-- Ubuntu 13.04
-- Ubuntu 14.04
+- Debian
+- Ubuntu
 %>
 <%
   partitioning_method = @host.params['partitioning-method'] ? @host.params['partitioning-method'] : 'regular'

--- a/preseed/disklayout_lvm.erb
+++ b/preseed/disklayout_lvm.erb
@@ -2,13 +2,8 @@
 kind: ptable
 name: Preseed default LVM
 oses:
-- Debian 6.0
-- Debian 7.
-- Debian 8.
-- Ubuntu 10.04
-- Ubuntu 12.04
-- Ubuntu 13.04
-- Ubuntu 14.04
+- Debian
+- Ubuntu
 %>
 <%
   partitioning_method = @host.params['partitioning-method'] ? @host.params['partitioning-method'] : 'lvm'

--- a/preseed/finish.erb
+++ b/preseed/finish.erb
@@ -2,13 +2,8 @@
 kind: finish
 name: Preseed default finish
 oses:
-- Debian 6.0
-- Debian 7.
-- Debian 8.
-- Ubuntu 10.04
-- Ubuntu 12.04
-- Ubuntu 13.04
-- Ubuntu 14.04
+- Debian
+- Ubuntu
 %>
 <%
   # safemode renderer does not support unary negation

--- a/preseed/iPXE.erb
+++ b/preseed/iPXE.erb
@@ -3,11 +3,8 @@
 kind: iPXE
 name: Preseed default iPXE
 oses:
-- Debian 6.0
-- Debian 7.
-- Debian 8.
-- Ubuntu 12.04
-- Ubuntu 14.04
+- Debian
+- Ubuntu
 %>
 <% if @host.operatingsystem.name == 'Debian' -%>
 <% keyboard_params = "auto=true domain=#{@host.domain}" -%>

--- a/preseed/provision.erb
+++ b/preseed/provision.erb
@@ -2,13 +2,8 @@
 kind: provision
 name: Preseed default
 oses:
-- Debian 6.0
-- Debian 7.
-- Debian 8.
-- Ubuntu 10.04
-- Ubuntu 12.04
-- Ubuntu 13.04
-- Ubuntu 14.04
+- Debian
+- Ubuntu
 %>
 <%
   # safemode renderer does not support unary negation

--- a/preseed/userdata.erb
+++ b/preseed/userdata.erb
@@ -2,11 +2,8 @@
 kind: user_data
 name: Preseed default user data
 oses:
-- Debian 6.0
-- Debian 7.
-- Debian 8.
-- Ubuntu 12.04
-- Ubuntu 14.04
+- Debian
+- Ubuntu
 -%>
 #!/bin/bash
 


### PR DESCRIPTION
This make future releases and non-LTS Ubuntu releases automatically associate, and also fixes divergence between files
