### PR TITLE
Removed Docker tcp socket

### DIFF
--- a/coreos/README.md
+++ b/coreos/README.md
@@ -5,6 +5,7 @@ The templates use some Host Parameters to contol the flow of the template. These
 * install-disk: What device to install to (default: /dev/sda | /dev/vda)
 * ssh_authorized_keys: add public SSH keys which will be authorized for the core user. You can specify multiple SSH keys seperated with a "," (default: empty)
 * etcd_discovery_url: provision a discovery token for etcd to allow a simple cluster deployment. You can get a new discovery token at [https://discovery.etcd.io/new](https://discovery.etcd.io/new). This parameter is used in the [coreos_cloudconfig snippet](https://github.com/theforeman/community-templates/blob/develop/snippets/coreos_cloudconfig.erb). (default: empty)
+* expose_docker_socket: if you want to have an exposed Docker TCP socket set this to "true"
 
 If you don't add any SSH keys you can login with the core user using the root password.
 

--- a/snippets/coreos_cloudconfig.erb
+++ b/snippets/coreos_cloudconfig.erb
@@ -17,6 +17,7 @@ name: coreos_cloudconfig
             command: start
           - name: fleet.service
             command: start
+<% if @host.param_true?('expose_docker_socket') -%>
           - name: docker-tcp.socket
             command: start
             enable: yes
@@ -40,6 +41,7 @@ name: coreos_cloudconfig
               [Service]
               Type=oneshot
               ExecStart=/usr/bin/systemctl enable docker-tcp.socket
+<% end -%>
 <% if @host.subnet.respond_to?(:dhcp_boot_mode?) -%>
 <% dhcp = @host.subnet.dhcp_boot_mode? && !@static -%>
 <% else -%>


### PR DESCRIPTION
I think there is no need to expose the Docker TCP socket. Most people will login into the Machine and run their containers during their SSH session or will use a cluster scheduler like [Kubernetes](https://github.com/kubernetes/kubernetes), [Mesos](https://mesos.apache.org), [Swarm](https://docs.docker.com/swarm), [fleet](https://github.com/coreos/fleet) or something else, so that there is no need to have a Docker socket exposed.

 From the [Docker docs](https://docs.docker.com/engine/userguide/basics):
"Warning: Changing the default docker daemon binding to a TCP port or Unix docker user group will increase your security risks by allowing non-root users to gain root access on the host. Make sure you control access to docker. If you are binding to a TCP port, anyone with access to that port has full Docker access; so it is not advisable on an open network."
