### PR TITLE
Remove deprecated etcd ports

### DIFF
--- a/snippets/coreos_cloudconfig.erb
+++ b/snippets/coreos_cloudconfig.erb
@@ -8,10 +8,10 @@ name: coreos_cloudconfig
 <% if @host.params['etcd_discovery_url'] -%>
           discovery: <%= @host.params['etcd_discovery_url'] %>
 <% end -%>
-          advertise-client-urls: http://<%= @host.ip %>:2379,http://<%= @host.ip %>:4001
-          initial-advertise-peer-urls: http://<%= @host.ip %>:2380,http://<%= @host.ip %>:7001
-          listen-client-urls: http://0.0.0.0:2379,http://0.0.0.0:4001
-          listen-peer-urls: http://0.0.0.0:2380,http://0.0.0.0:7001
+          advertise-client-urls: http://<%= @host.ip %>:2379
+          initial-advertise-peer-urls: http://<%= @host.ip %>:2380
+          listen-client-urls: http://0.0.0.0:2379
+          listen-peer-urls: http://0.0.0.0:2380
         units:
           - name: etcd2.service
             command: start


### PR DESCRIPTION
I think we should remove the old deprecated etcd ports. People who spin up a new CoreOS cluster don't need these deprecated ports (and should use the new [standardized ports](https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml?search=etcd)). By removing the old ports we make it easier for new people to use the right ports in their setup.
