### PR TITLE
Add a conditional to set net.ifnames=0 on the kernel command line

### DIFF
--- a/kickstart/PXELinux.erb
+++ b/kickstart/PXELinux.erb
@@ -37,11 +37,11 @@ DEFAULT linux
 LABEL linux
     KERNEL <%= @kernel %>
     <% if @host.operatingsystem.name.match(/.*atomic.*/i) %>
-    APPEND initrd=<%= @initrd %> ks=<%= foreman_url('provision') %> repo=<%= @host.operatingsystem.medium_uri(@host) %> ks.device=bootif network ks.sendmac <%= options %>
+    APPEND initrd=<%= @initrd %> ks=<%= foreman_url('provision') %> repo=<%= @host.operatingsystem.medium_uri(@host) %> ks.device=bootif network ks.sendmac <%= options %> <%= 'net.ifnames=0' if ['VMWare'].include?(@host.provider)%>
     <% elsif @host.operatingsystem.name == 'Fedora' and @host.operatingsystem.major.to_i > 16 -%>
-    APPEND initrd=<%= @initrd %> ks=<%= foreman_url('provision')%> ks.device=bootif network ks.sendmac <%= options %>
+    APPEND initrd=<%= @initrd %> ks=<%= foreman_url('provision')%> ks.device=bootif network ks.sendmac <%= options %> <%= 'net.ifnames=0' if ['VMWare'].include?(@host.provider)%>
     <% elsif @host.operatingsystem.name != 'Fedora' and @host.operatingsystem.major.to_i >= 7 -%>
-    APPEND initrd=<%= @initrd %> ks=<%= foreman_url('provision')%> network ks.sendmac <%= options %>
+    APPEND initrd=<%= @initrd %> ks=<%= foreman_url('provision')%> network ks.sendmac <%= options %> <%= 'net.ifnames=0' if ['VMWare'].include?(@host.provider)%>
     <% else -%>
     APPEND initrd=<%= @initrd %> ks=<%= foreman_url('provision')%> ksdevice=bootif network kssendmac <%= options %>
     <% end -%>

--- a/kickstart/iPXE.erb
+++ b/kickstart/iPXE.erb
@@ -26,7 +26,7 @@ oses:
 <%# This template will not function with Safemode set to true.
     Please disable it in Settings > Provisioning               %>
 
-kernel <%= "#{@host.url_for_boot(:kernel)}" %> ks=<%= foreman_url('provision')%><%= static %> ksdevice=<%= @host.mac %> network kssendmac ip=${netX/ip} netmask=${netX/netmask} gateway=${netX/gateway} dns=${dns}
+kernel <%= "#{@host.url_for_boot(:kernel)}" %> ks=<%= foreman_url('provision')%><%= static %> ksdevice=<%= @host.mac %> network kssendmac ip=${netX/ip} netmask=${netX/netmask} gateway=${netX/gateway} dns=${dns} <%= 'net.ifnames=0' if ['VMWare'].include?(@host.provider)%>
 initrd <%= "#{@host.url_for_boot(:initrd)}" %>
 
 boot

--- a/kickstart/provision.erb
+++ b/kickstart/provision.erb
@@ -87,7 +87,7 @@ repo --name=puppetlabs-deps --baseurl=http://yum.puppetlabs.com/el/<%= @host.ope
 bootloader --append="<%= @host.params['bootloader-append'] || 'nofb quiet splash=quiet' %> <%=ks_console%>" <%= grub_pass %>
 part biosboot --fstype=biosboot --size=1
 <% else -%>
-bootloader --location=mbr --append="<%= @host.params['bootloader-append'] || 'nofb quiet splash=quiet' %>" <%= grub_pass %>
+bootloader --location=mbr --append="<%= @host.params['bootloader-append'] || 'nofb quiet splash=quiet' %> <%= 'net.ifnames=0' if ['VMWare'].include?(@host.provider)-%>" <%= grub_pass %>
 <% end -%>
 
 <% if @dynamic -%>

--- a/kickstart/provision_rhel.erb
+++ b/kickstart/provision_rhel.erb
@@ -66,7 +66,7 @@ repo --name=puppetlabs-deps --baseurl=http://yum.puppetlabs.com/el/<%= @host.ope
 <% end -%>
 <% end -%>
 
-bootloader --location=mbr --append="<%= @host.params['bootloader-append'] || 'nofb quiet splash=quiet' %>" <%= grub_pass %>
+bootloader --location=mbr --append="<%= @host.params['bootloader-append'] || 'nofb quiet splash=quiet' %> <%= 'net.ifnames=0' if ['VMWare'].include?(@host.provider)-%>" <%= grub_pass %>
 <% if os_major == 5 -%>
 key --skip
 <% end -%>


### PR DESCRIPTION
If the compute resource provider is 'VMWare'.

Predictable network names are not predictable on VMWare, it is better
to fall back to the kernel default network device naming by adding <%= 'net.ifnames=0' if ['VMWare'].include?(@host.provider)%> to kernel command line in iPXE, PXELINUX and provisioning templates.
