### PR TITLE
Fixes #13362 - Remove upstream parameter from Fedora Atomic kickstart

### DIFF
--- a/kickstart/provision_atomic.erb
+++ b/kickstart/provision_atomic.erb
@@ -18,7 +18,10 @@ bootloader --timeout=3
 text
 
 <% if @host.os.name.match /.*fedora.*/i -%>
-ostreesetup --nogpg --osname=fedora-atomic --remote=fedora-atomic --url=<%= @host.param_true?('atomic-upstream') ? "https://dl.fedoraproject.org/pub/fedora/linux/atomic/#{@host.os.major}/" : "#{@host.operatingsystem.medium_uri(@host)}/content/repo/" %> --ref=fedora-atomic/f<%= @host.os.major %>/<%= @host.architecture %>/docker-host
+# Use @host.operatingsystem.medium_uri(@host)}/content/repo/ as the URL if you
+# have set up a local installation media for Fedora
+<% fedora_atomic_url = @host.params['atomic_refs_url'] || "https://dl.fedoraproject.org/pub/fedora/linux/atomic/#{@host.os.major}/" %>
+ostreesetup --nogpg --osname=fedora-atomic --remote=fedora-atomic --url=<%= fedora_atomic_url %> --ref=fedora-atomic/f<%= @host.os.major %>/<%= @host.architecture %>/docker-host
 <% elsif @host.os.name.match /.*centos.*/i -%>
 ostreesetup --nogpg --osname=centos-atomic-host --remote=centos-atomic-host --url=<%= @host.param_true?('atomic-upstream') ? "http://mirror.centos.org/centos/#{@host.os.major}/atomic/#{@host.architecture}/repo/" : @host.operatingsystem.medium_uri(@host) %> --ref=centos-atomic-host/<%= @host.os.major %>/<%= @host.architecture %>/standard
 <% else -%>


### PR DESCRIPTION
Fedora Atomic can be provisioned now from upstream entirely,
removing the need for this parameter.

Before http://projects.theforeman.org/issues/13340 ,
we had to set up a local installation media for the PXE boot stuff. So
provisioning from upstream was optional. Now, we can default to
provision from upstream and anyone with a custom installation media can
change the kickstart to use it.

CentOS unfortunately still has to be provisioned through a local
installation media so I'm not changing that line.
