### PR TITLE
Setup SSH keys during provision automatically

### DIFF
--- a/autoyast/provision.erb
+++ b/autoyast/provision.erb
@@ -135,6 +135,8 @@ chkconfig salt-minion on
 salt-call --no-color --grains >/dev/null
 <% end -%>
 
+<%= snippet('remote_execution_ssh_keys') %>
+
 /usr/bin/curl -o /dev/null -k '<%= foreman_url %>'
 
 rm /etc/resolv.conf

--- a/freebsd/provision_FreeBSD_mfsBSD.erb
+++ b/freebsd/provision_FreeBSD_mfsBSD.erb
@@ -22,6 +22,8 @@ fetch -q --no-verify-hostname --no-verify-peer -o /mnt/tmp/finish.sh -d <%= fore
 chroot /mnt /bin/sh /tmp/finish.sh
 rm /mnt/tmp/finish.sh
 
+<%= snippet('remote_execution_ssh_keys') %>
+
 fetch -q --no-verify-hostname --no-verify-peer -o /dev/null -d <%= foreman_url %>
 sleep 5
 reboot

--- a/kickstart/provision.erb
+++ b/kickstart/provision.erb
@@ -176,6 +176,8 @@ cat > /etc/puppet/puppet.conf << EOF
 <%= snippet 'puppet.conf' %>
 EOF
 
+<%= snippet('remote_execution_ssh_keys') %>
+
 # Setup puppet to run on system reboot
 /sbin/chkconfig --level 345 puppet on
 

--- a/preseed/provision.erb
+++ b/preseed/provision.erb
@@ -132,6 +132,8 @@ d-i apt-setup/backports boolean true
   <% puppet_package = '' -%>
 <% end -%>
 
+<%= snippet('remote_execution_ssh_keys') %>
+
 # Install some base packages
 d-i pkgsel/include string <%= puppet_package %> <%= salt_package %> lsb-release
 d-i pkgsel/update-policy select unattended-upgrades

--- a/snippets/remote_execution_ssh_keys.erb
+++ b/snippets/remote_execution_ssh_keys.erb
@@ -1,0 +1,35 @@
+<%#
+  kind: snippet
+  name: remote_execution_ssh_keys
+%>
+# SSH keys setup snippet
+#
+# Parameters:
+#
+# remote_execution_ssh_keys: public keys to be put in ~/.ssh/authorized_keys
+#
+# remote_execution_ssh_user: user for which remote_execution_ssh_keys will be
+#                            authorized
+#
+# This template sets up SSH keys in any host so that as long as your public
+# SSH key is in remote_execution_ssh_keys, you can SSH into a host.
+
+# A personal recomendation: create a global parameter remote_execution_ssh_keys
+# and put your keys there, so that you can access any newly provisioned host
+# without having to set up the parameter on every host or host group.
+
+
+<% if !@host.params['remote_execution_ssh_keys'].blank? %>
+<% ssh_user = @host.params['remote_execution_ssh_user'] || 'root' %>
+<% ssh_path = "~#{ssh_user}/.ssh" %>
+
+mkdir -p <%= ssh_path %>
+
+cat << EOF >> <%= ssh_path %>/authorized_keys
+<%= @host.params['remote_execution_ssh_keys'].join("\n") %>
+EOF
+
+chmod 700 <%= ssh_path %>
+chmod 600 <%= ssh_path %>/authorized_keys
+chown -R <%= "#{ssh_user}:#{ssh_user}" %> <%= ssh_path %>
+<% end %>


### PR DESCRIPTION
I took this snippet from the remote_execution plugin, so perhaps the
name should be changed to just 'setup_ssh_keys'.

This change should allow people to set a global or per-host/group
parameter that sets up SSH authorized_keys automatically on new hosts.

We can document this on the manual on a section 'how to set up
automatic SSH authorized_keys'.
