### PR TITLE
Fix issue #13684 RHN registration on RHEL 5

### DIFF
--- a/snippets/redhat_register.erb
+++ b/snippets/redhat_register.erb
@@ -126,15 +126,13 @@ name: redhat_register
   <% end %>
 <% else %>
   echo "Starting the subscription-manager registration process"
-  yum -t -y -e 0 install subscription-manager <%= @host.operatingsystem.major.to_i >= 6 ? 'yum-config-manager' : '' %> 
-  
-  <% if @host.operatingsystem.major.to_i >= 6  %> 
+  yum -t -y -e 0 install subscription-manager <%= @host.operatingsystem.major.to_i >= 6 ? 'yum-config-manager' : '' %>
+
+  <% if @host.operatingsystem.major.to_i >= 6  %>
     <% ( enabled_repos = "yum-config-manager --enable #{@host.params['subscription_manager_repos'].gsub(',', ' ')}") if @host.params['subscription_manager_repos'] %>
   <% else %>
     <% ( enabled_repos = "subscription-manager repos --enable #{@host.params['subscription_manager_repos'].gsub(',', ' --enable')}") if @host.params['subscription_manager_repos'] %>
   <% end %>
-  
-  
   <% if @host.params['http-proxy'] %>
     subscription-manager config --server.proxy_hostname="<%= @host.params['http-proxy'] %>"
     <% if @host.params['http-proxy-user'] %>
@@ -166,11 +164,9 @@ name: redhat_register
     subscription-manager register --org="<%= @host.params['subscription_manager_org'] %>" --activationkey="<%= @host.params['activation_key'] %>"
     # workaround for RHEL 6.4 bug https://bugzilla.redhat.com/show_bug.cgi?id=1008016
     subscription-manager repos --list > /dev/null
-     
     <%= enabled_repos if enabled_repos %>
   <% else %>
     # Not registering host.params['activation_key'] not found.
   <% end %>
 <% end %>
 # End Red Hat Registration Snippet
-

--- a/snippets/redhat_register.erb
+++ b/snippets/redhat_register.erb
@@ -127,7 +127,6 @@ name: redhat_register
 <% else %>
   echo "Starting the subscription-manager registration process"
   yum -t -y -e 0 install subscription-manager <%= @host.operatingsystem.major.to_i >= 6 ? 'yum-config-manager' : '' %>
-
   <% if @host.operatingsystem.major.to_i >= 6  %>
     <% ( enabled_repos = "yum-config-manager --enable #{@host.params['subscription_manager_repos'].gsub(',', ' ')}") if @host.params['subscription_manager_repos'] %>
   <% else %>

--- a/snippets/redhat_register.erb
+++ b/snippets/redhat_register.erb
@@ -126,8 +126,15 @@ name: redhat_register
   <% end %>
 <% else %>
   echo "Starting the subscription-manager registration process"
-  yum -t -y -e 0 install subscription-manager yum-utils
-  <% (enabled_repos = "yum-config-manager --enable #{@host.params['subscription_manager_repos'].gsub(',', ' ')}") if @host.params['subscription_manager_repos'] %>
+  yum -t -y -e 0 install subscription-manager <%= @host.operatingsystem.major.to_i >= 6 ? 'yum-config-manager' : '' %> 
+  
+  <% if @host.operatingsystem.major.to_i >= 6  %> 
+    <% ( enabled_repos = "yum-config-manager --enable #{@host.params['subscription_manager_repos'].gsub(',', ' ')}") if @host.params['subscription_manager_repos'] %>
+  <% else %>
+    <% ( enabled_repos = "subscription-manager repos --enable #{@host.params['subscription_manager_repos'].gsub(',', ' --enable')}") if @host.params['subscription_manager_repos'] %>
+  <% end %>
+  
+  
   <% if @host.params['http-proxy'] %>
     subscription-manager config --server.proxy_hostname="<%= @host.params['http-proxy'] %>"
     <% if @host.params['http-proxy-user'] %>
@@ -159,9 +166,11 @@ name: redhat_register
     subscription-manager register --org="<%= @host.params['subscription_manager_org'] %>" --activationkey="<%= @host.params['activation_key'] %>"
     # workaround for RHEL 6.4 bug https://bugzilla.redhat.com/show_bug.cgi?id=1008016
     subscription-manager repos --list > /dev/null
+     
     <%= enabled_repos if enabled_repos %>
   <% else %>
     # Not registering host.params['activation_key'] not found.
   <% end %>
 <% end %>
 # End Red Hat Registration Snippet
+


### PR DESCRIPTION
This is a proposed patch to fix issue #13684 RHN registration on RHEL 5. The patch modifies the code to use subscription-manager if the host is RHEL 5 or older.
