### PR TITLE
FIX: fixes #13724, which creates invalid devices on RHEL 5

### DIFF
--- a/snippets/kickstart_networking_setup.erb
+++ b/snippets/kickstart_networking_setup.erb
@@ -23,7 +23,7 @@ NETMASK="<%= subnet.mask -%>"
 GATEWAY="<%= subnet.gateway %>"
 <% end -%>
 <% end -%>
-DEVICE="$real"
+DEVICE=$real
 HWADDR="<%= @host.mac -%>"
 ONBOOT=yes
 EOF
@@ -46,7 +46,7 @@ NETMASK="<%= subnet.mask -%>"
 GATEWAY="<%= subnet.gateway %>"
 <% end -%>
 <% end -%>
-DEVICE="$real"
+DEVICE=$real
 ONBOOT=yes
 PEERDNS=no
 PEERROUTES=no
@@ -81,7 +81,7 @@ sanitized_real=$real
 
 cat << EOF > /etc/sysconfig/network-scripts/ifcfg-$sanitized_real
 BOOTPROTO="none"
-DEVICE="$real"
+DEVICE=$real
 <% unless virtual -%>
 HWADDR="<%= interface.mac -%>"
 <% end -%>
@@ -134,7 +134,7 @@ NETMASK="<%= subnet.mask -%>"
 GATEWAY="<%= subnet.gateway %>"
 <% end -%>
 <% end -%>
-DEVICE="$real"
+DEVICE=$real
 <% unless virtual -%>
 HWADDR="<%= interface.mac -%>"
 <% end -%>


### PR DESCRIPTION
Hello, this is a proposed patch for issue #13724 (Invalid network devices on RHEL 5). The issue may also affect CentOS 5 but I did not test on that.
