### PR TITLE
Add SSH authorized_keys to cloud-init script

### DIFF
--- a/cloudinit/userdata_cloudinit.erb
+++ b/cloudinit/userdata_cloudinit.erb
@@ -20,6 +20,13 @@ oses:
 hostname: <%= @host.shortname %>
 fqdn: <%= @host %>
 manage_etc_hosts: true
+ssh_pwauth: <%= @host.params['ssh_pwauth'] || true %>
+<% if @host.params['ssh_authorized_keys'] -%>
+ssh_authorized_keys:
+<% @host.params['ssh_authorized_keys'].split("\n").each do |ssh_key| -%>
+ - <%= ssh_key %>
+<% end -%>
+<% end -%>
 
 groups:
  - admin


### PR DESCRIPTION
Some systems like Fedora/CentOS/RHEL Atomic won't allow you to set passwords to their root user. In this case ssh keys have to be used. This reads a parameter ssh_authorized_keys (that coreOS uses already) and puts these keys in the authorized_files for root via cloudinit.

cc @stbenjam @inecas @ares - how about changing the remote execution SSH keys parameter to this?  It's already being used in the cloudconfig and provision scripts for CoreOS, and it's easier to understand than 'remote_execution_ssh_keys'. The idea is that users will create a global or host group parameter 'ssh_authorized_keys' and put there their keys - currently they have to create 2, one for CoreOS, another for remote execution.
