### PR TITLE
refs #10926 - eject bootdisk when host is bootdisk provisioned

### DIFF
--- a/kickstart/provision.erb
+++ b/kickstart/provision.erb
@@ -97,7 +97,11 @@ bootloader --location=mbr --append="<%= @host.params['bootloader-append'] || 'no
 <% end -%>
 
 text
+<% if @host.respond_to?(:bootdisk_build?) && @host.bootdisk_build? %>
+reboot --eject
+<% else -%>
 reboot
+<% end -%>
 
 %packages
 yum


### PR DESCRIPTION
This PR adds the ability to eject the bootdisk after installation when the host is provisioned via bootdisk.

This unfortunately does not work for rhel 7. There is already a bug opened. https://bugzilla.redhat.com/show_bug.cgi?id=1191386

See:
https://github.com/theforeman/foreman_bootdisk/pull/19
