### PR TITLE
Update remote_execution_ssh_keys.erb

### DIFF
--- a/snippets/remote_execution_ssh_keys.erb
+++ b/snippets/remote_execution_ssh_keys.erb
@@ -26,7 +26,7 @@
 mkdir -p <%= ssh_path %>
 
 cat << EOF >> <%= ssh_path %>/authorized_keys
-<%= @host.params['remote_execution_ssh_keys'].join("\n") %>
+<%= @host.params['remote_execution_ssh_keys'] %>
 EOF
 
 chmod 700 <%= ssh_path %>


### PR DESCRIPTION
foreman threw an error: undefined method 'join' for...

Remove illegal call to .join
