### PR TITLE
Use foreman_server_fqdn helper in global default

### DIFF
--- a/pxe/PXELinux_default.erb
+++ b/pxe/PXELinux_default.erb
@@ -20,7 +20,7 @@ LABEL local
 LABEL discovery
      MENU LABEL (discovery)
      KERNEL boot/fdi-image/vmlinuz0
-     APPEND initrd=boot/fdi-image/initrd0.img rootflags=loop root=live:/fdi.iso rootfstype=auto ro rd.live.image acpi=force rd.luks=0 rd.md=0 rd.dm=0 rd.lvm=0 rd.bootif=0 rd.neednet=0 nomodeset proxy.url=https://FOREMAN_INSTANCE proxy.type=foreman
+     APPEND initrd=boot/fdi-image/initrd0.img rootflags=loop root=live:/fdi.iso rootfstype=auto ro rd.live.image acpi=force rd.luks=0 rd.md=0 rd.dm=0 rd.lvm=0 rd.bootif=0 rd.neednet=0 nomodeset proxy.url=<%= foreman_server_url %> proxy.type=foreman
      IPAPPEND 2
 
 <% for profile in @profiles -%>


### PR DESCRIPTION
Since https://github.com/theforeman/foreman/pull/3335 introduced the helper
method, we can use it in the discovery block. If user want to use smart-proxy
for discovery, he still must edit this. But this is small improvement.
