### PR TITLE
Add better support for FreeBSD template

### DIFF
--- a/freebsd/disklayout_FreeBSD_mfsBSD-UFS.erb
+++ b/freebsd/disklayout_FreeBSD_mfsBSD-UFS.erb
@@ -1,0 +1,11 @@
+<%#
+kind: ptable
+name: FreeBSD UFS Template
+oses:
+- FreeBSD
+%>
+
+4G freebsd-ufs /,
+2G freebsd-swap,
+2G freebsd-ufs /var,
+auto freebsd-ufs /usr

--- a/freebsd/finish_FreeBSD_mfsBSD.erb
+++ b/freebsd/finish_FreeBSD_mfsBSD.erb
@@ -34,7 +34,8 @@ adjkerntz -a
 ntpdate <%= @host.params['ntp-server'] || '0.freebsd.pool.ntp.org' %>
 env ASSUME_ALWAYS_YES=YES pkg bootstrap
 
-<%= snippet 'FreeBSD_Local_Repository' %>
+# Define in a repo file were to get the packages comment out this, if it's defined
+#<%= snippet 'FreeBSD_Local_Repository' %>
 
 mkdir /root/install/
 freebsd-update fetch > /root/install/freebsd-update_fetch.txt

--- a/freebsd/finish_FreeBSD_mfsBSD.erb
+++ b/freebsd/finish_FreeBSD_mfsBSD.erb
@@ -11,7 +11,12 @@ oses:
   salt_enabled = @host.params['salt_master'] ? true : false
   proxy_string = @host.params['http-proxy'] ? "http://#{@host.params['http-proxy']}:#{@host.params['http-proxy-port']}" : ''
 %>
+
+# Do not define http_proxy if empty or freebsd-update will fail.
+<% if proxy_string != '' -%>
 export http_proxy='<%= proxy_string %>'
+<% end -%>
+
 /bin/echo '<%= root_pass %>' | pw usermod root -H 0
 cat >> /etc/rc.conf <<EOF
 hostname="<%= @host %>"
@@ -28,6 +33,15 @@ cp /usr/share/zoneinfo/<%= @host.params['time-zone'] || 'UTC' %> /etc/localtime
 adjkerntz -a
 ntpdate <%= @host.params['ntp-server'] || '0.freebsd.pool.ntp.org' %>
 env ASSUME_ALWAYS_YES=YES pkg bootstrap
+
+<%= snippet 'FreeBSD_Local_Repository' %>
+
+mkdir /root/install/
+freebsd-update fetch > /root/install/freebsd-update_fetch.txt
+freebsd-update install > /root/install/freebsd-update_install.txt
+
+pkg update > /root/install/pkg_update.txt
+pkg upgrade -y > /root/install/pkg_upgrade.txt
 
 <% if puppet_enabled %>
 <%= snippet 'puppet_setup' %>

--- a/freebsd/provision_FreeBSD_mfsBSD-UFS.erb
+++ b/freebsd/provision_FreeBSD_mfsBSD-UFS.erb
@@ -1,0 +1,56 @@
+<%#
+kind: provision
+name: FreeBSD (mfsBSD) provision UFS
+oses:
+- FreeBSD
+%>
+<%
+proxy_string = @host.params['http-proxy'] ? "http://#{@host.params['http-proxy']}:#{@host.params['http-proxy-port']}" : ''
+%>
+# Do not define http_proxy if empty or freebsd-update will fail.
+<% if proxy_string != '' -%>
+export http_proxy='<%= proxy_string %>'
+<% end -%>
+
+# Get the disk layout, and the first disk connected to the system
+disk_layout=`/sbin/sysctl -n kern.disks | /usr/bin/sed 's/cd[0-9]//g'`
+first_disk="`echo ${disk_layout##*[1-9]} | /usr/bin/cut -d' ' -f1`"
+test -z "$first_disk" || echo "First disk: $first_disk"
+
+/root/bin/destroygeom -d <%= @host.params['install-disk'] || '$first_disk' %> || exit 1
+
+export DISTRIBUTIONS="kernel.txz base.txz"
+export BSDINSTALL_DISTDIR="/tmp"
+export BSDINSTALL_DISTSITE="ftp://ftp.freebsd.org/pub/FreeBSD/releases/amd64/<%= @host.operatingsystem.major %>.<%= @host.operatingsystem.minor %>-RELEASE"
+export ASSUME_ALWAYS_YES="yes"
+
+cat <<EOF> /tmp/installer
+PARTITIONS="<%= @host.params['install-disk'] || '$first_disk' %> {<%= @host.diskLayout %>}"
+DISTRIBUTIONS="${DISTRIBUTIONS}"
+BSDINSTALL_DISTDIR=${BSDINSTALL_DISTDIR}
+BSDINSTALL_DISTSITE=${BSDINSTALL_DISTSITE}
+ASSUME_ALWAYS_YES=${ASSUME_ALWAYS_YES}
+
+#!/bin/sh
+echo "Installation complete, running in host system"
+
+echo "Setup done" >> /tmp/log.txt
+echo "Setup done."
+
+EOF
+
+bsdinstall distfetch
+bsdinstall script /tmp/installer
+bsdinstall mount
+
+mount -t devfs devfs /mnt/dev
+
+cp /etc/resolv.conf /mnt/etc/resolv.conf
+
+fetch -q --no-verify-hostname --no-verify-peer -o /mnt/tmp/finish.sh -d <%= foreman_url('finish') %>
+chroot /mnt /bin/sh /tmp/finish.sh
+rm /mnt/tmp/finish.sh
+
+fetch -q --no-verify-hostname --no-verify-peer -o /dev/null -d <%= foreman_url %>
+sleep 5
+reboot

--- a/freebsd/provision_FreeBSD_mfsBSD.erb
+++ b/freebsd/provision_FreeBSD_mfsBSD.erb
@@ -7,7 +7,11 @@ oses:
 <%
 proxy_string = @host.params['http-proxy'] ? "http://#{@host.params['http-proxy']}:#{@host.params['http-proxy-port']}" : ''
 %>
+# Do not define http_proxy if empty or freebsd-update will fail.
+<% if proxy_string != '' -%>
 export http_proxy='<%= proxy_string %>'
+<% end %>
+
 # Get the disk layout, and the first disk connected to the system
 disk_layout=`/sbin/sysctl -n kern.disks | /usr/bin/sed 's/cd[0-9]//g'`
 first_disk="`echo ${disk_layout##*[1-9]} | /usr/bin/cut -d' ' -f1`"

--- a/freebsd/provision_FreeBSD_mfsBSD.erb
+++ b/freebsd/provision_FreeBSD_mfsBSD.erb
@@ -10,7 +10,7 @@ proxy_string = @host.params['http-proxy'] ? "http://#{@host.params['http-proxy']
 # Do not define http_proxy if empty or freebsd-update will fail.
 <% if proxy_string != '' -%>
 export http_proxy='<%= proxy_string %>'
-<% end %>
+<% end -%>
 
 # Get the disk layout, and the first disk connected to the system
 disk_layout=`/sbin/sysctl -n kern.disks | /usr/bin/sed 's/cd[0-9]//g'`

--- a/snippets/freebsd_local_repository.erb
+++ b/snippets/freebsd_local_repository.erb
@@ -1,0 +1,12 @@
+<%#
+kind: snippet
+name: FreeBSD_Local_Repository
+%>
+mkdir -p /usr/local/etc/pkg/repos
+cat <<EOF2> /usr/local/etc/pkg/repos/local_repo.conf 
+local_repo: {
+  url: "pkg+http://local_repo/packages/",
+  mirror_type: srv,
+  enabled: yes
+}
+EOF2


### PR DESCRIPTION
Changes
fixes :
- a bug with http_proxy that block freebsd-update to fetch patches.

Enhancement :
- add the freebsd-update process after installing the OS to avoid to install them after installation
- allow disk templating for UFS based freebsd system
