### PR TITLE
Fix puppet4 service not being enabled on RHEL

### DIFF
--- a/snippets/puppet_setup.erb
+++ b/snippets/puppet_setup.erb
@@ -32,6 +32,14 @@ cat > <%= etc_path %>/puppet.conf << EOF
 <%= snippet 'puppet.conf' %>
 EOF
 
+<% if @host.operatingsystem.family == 'Redhat' -%>
+<% if @host.operatingsystem.major.to_i > 6 -%>
+puppet_unit=puppet
+/usr/bin/systemctl list-unit-files | grep -q puppetagent && puppet_unit=puppetagent
+/usr/bin/systemctl enable ${puppet_unit}
+<% end -%>
+/sbin/chkconfig --level 345 puppet on
+<% end -%>
 <% unless @host.param_true?('enable-puppetlabs-pc1-repo') -%>
 <% if @host.operatingsystem.family == 'Debian' -%>
 if [ -f "/etc/default/puppet" ]
@@ -41,12 +49,6 @@ fi
 /usr/bin/puppet agent --enable
 <% elsif @host.operatingsystem.family == 'Freebsd' -%>
 echo 'puppet_enable="YES"' >>/etc/rc.conf
-<% elsif @host.operatingsystem.name == 'Fedora' -%>
-puppet_unit=puppet
-/usr/bin/systemctl list-unit-files | grep -q puppetagent && puppet_unit=puppetagent
-/usr/bin/systemctl enable ${puppet_unit}
-<% elsif @host.operatingsystem.family == 'Redhat' -%>
-/sbin/chkconfig --level 345 puppet on
 <% elsif @host.operatingsystem.family == 'Suse' -%>
 if [ -f "/etc/sysconfig/puppet" ]
 then


### PR DESCRIPTION
Due to https://github.com/theforeman/community-templates/commit/8eca3cf8665d6193b5b34a27fc118469a8598c3a#diff-8048fb7fe5c29050e20a1a592d25a6c0R35
none of the puppet agent service enabling code was being run after
puppet is installed from the PC1 repository.  After discussing on IRC,
it may be that at least for some platforms the service is enabled by
default on installation.  For both EL6 and EL7 this wasn't the case.

This commit fixes this and has been tested on Oracle Linux 6 and 7.
