### PR TITLE
Hostgroup name shall be first in pxe menu label

### DIFF
--- a/pxe/PXELinux_default.erb
+++ b/pxe/PXELinux_default.erb
@@ -20,7 +20,7 @@ LABEL local
 <%= snippet "pxelinux_discovery" %>
 
 <% for profile in @profiles -%>
-LABEL <%= "#{profile[:template]} - #{profile[:hostgroup]}" %>
+LABEL <%= "#{profile[:hostgroup]} - #{profile[:template]}" %>
      KERNEL <%= profile[:hostgroup].operatingsystem.kernel(profile[:hostgroup].architecture) %>
 <% case profile[:hostgroup].operatingsystem.pxe_type -%>
 <% when 'kickstart' -%>


### PR DESCRIPTION
According to [this](http://projects.theforeman.org/issues/6977) issue, The hostgroup name is more important for the server then the provisioning template name. The hostgroup defines really what it will get and also the content view afterwards.

You can find the  menu labels sorting PR [here](https://github.com/theforeman/foreman/pull/3457)   
