### PR TITLE
Fixes #14845: Use the first partition in preseed

### DIFF
--- a/preseed/README.md
+++ b/preseed/README.md
@@ -14,7 +14,7 @@ Tested on:
 
 The templates use some Host Parameters to contol the flow of the template. These are:
 
-* `install-disk`: What device to install to (default: `/dev/sda /dev/vda /dev/xvda`, the first available is picked)
+* `install-disk`: What device to install to (default: the first disk returned with `list-devices disk`)
 * `partitioning-method`: `regular` (default for `Preseed default`), `lvm` (default for `Preseed default lvm`) or `crypto`
 * `partitioning-recipe`: `atomic` (default for `Preseed default`), `home`, or `multi` (default for `Preseed default lvm`)
 * `partitioning-expert-recipe`: Entire recipe (default: empty, i.e `partitioning-recipe`)

--- a/preseed/disklayout.erb
+++ b/preseed/disklayout.erb
@@ -16,7 +16,8 @@ oses:
 <% if @host.params['install-disk'] -%>
 d-i partman-auto/disk string <%= @host.params['install-disk'] %>
 <% else -%>
-d-i partman-auto/disk string /dev/sda /dev/vda /dev/xvda
+# Use the first detected hard disk as default installation disk
+d-i partman/early_command string debconf-set partman-auto/disk "$(list-devices disk | head -n1)"
 <% end -%>
 
 ### Partitioning

--- a/preseed/disklayout_lvm.erb
+++ b/preseed/disklayout_lvm.erb
@@ -16,7 +16,8 @@ oses:
 <% if @host.params['install-disk'] -%>
 d-i partman-auto/disk string <%= @host.params['install-disk'] %>
 <% else -%>
-d-i partman-auto/disk string /dev/sda /dev/vda /dev/xvda
+# Use the first detected hard disk as default installation disk
+d-i partman/early_command string debconf-set partman-auto/disk "$(list-devices disk | head -n1)"
 <% end -%>
 
 ### Partitioning


### PR DESCRIPTION
Instead of hardcoding /dev/sda, use the first disk that the debian
installer detects through the `list-devices disk` command. This can still
select the wrong device for the particular setup, but at least does not
install into SD card devices any more (we had that happening a couple of
times).
