### PR TITLE
Fixes #15359 - UserData default should install an automation tool

### DIFF
--- a/cloudinit/userdata_cloudinit.erb
+++ b/cloudinit/userdata_cloudinit.erb
@@ -16,6 +16,12 @@ This template accepts the following parameters:
 -%>
 <%
   ssh_pwauth = @host.params['ssh_pwauth'] ? @host.param_true?('ssh_pwauth') : !@host.params['ssh_authorized_keys']
+  rhel_compatible = @host.operatingsystem.family == 'Redhat' && @host.operatingsystem.name != 'Fedora'
+  # safemode renderer does not support unary negation
+  pm_set = @host.puppetmaster.empty? ? false : true
+  puppet_enabled = pm_set || @host.param_true?('force-puppet')
+  salt_enabled = @host.params['salt_master'] ? true : false
+  chef_enabled = @host.respond_to?(:chef_proxy) && @host.chef_proxy
 -%>
 #cloud-config
 hostname: <%= @host.shortname %>
@@ -46,6 +52,28 @@ ssh_authorized_keys:
 
 <% if @host.param_true?('package_upgrade') -%>
 package_upgrade: true
+<% end -%>
+
+runcmd:
+<% if rhel_compatible -%>
+- |
+<%= indent(2) { snippet('epel') } %>
+<% end -%>
+- |
+<%= indent(2) { snippet('remote_execution_ssh_keys') } %>
+<% if chef_enabled -%>
+- |
+<%= indent(2) { snippet('chef_client') } %>
+<% end -%>
+<% if puppet_enabled -%>
+- |
+<%= indent(2) { snippet('puppetlabs_repo') } %>
+- |
+<%= indent(2) { snippet('puppet_setup') } %>
+<% end -%>
+<% if salt_enabled -%>
+- |
+<%= indent(2) { snippet('saltstack_setup') } %>
 <% end -%>
 
 <%# Contact Foreman to confirm instance is built -%>

--- a/kickstart/finish.erb
+++ b/kickstart/finish.erb
@@ -28,23 +28,6 @@ echo 'root:<%= root_pass -%>' | /usr/sbin/chpasswd -e
 <%= snippet 'epel' -%>
 <% end -%>
 
-<% if puppet_enabled -%>
-<% if @host.param_true?('enable-puppetlabs-repo') -%>
-<% if @host.operatingsystem.name == 'Fedora' -%>
-rpm -ivh http://yum.puppetlabs.com/puppetlabs-release-fedora-<%= os_major -%>.noarch.rpm
-<% else -%>
-rpm -ivh http://yum.puppetlabs.com/puppetlabs-release-el-<%= os_major -%>.noarch.rpm
-<% end -%>
-<% end -%>
-<% if @host.param_true?('enable-puppetlabs-pc1-repo') -%>
-<% if @host.operatingsystem.name == 'Fedora' -%>
-rpm -ivh http://yum.puppetlabs.com/puppetlabs-release-pc1-fedora-<%= os_major -%>.noarch.rpm
-<% else -%>
-rpm -ivh http://yum.puppetlabs.com/puppetlabs-release-pc1-el-<%= os_major -%>.noarch.rpm
-<% end -%>
-<% end -%>
-<% end -%>
-
 #update local time
 echo "updating system time"
 /usr/sbin/ntpdate -sub <%= @host.params['ntp-server'] || '0.fedora.pool.ntp.org' %>
@@ -64,6 +47,7 @@ yum -t -y update
 <% end -%>
 
 <% if puppet_enabled %>
+<%= snippet 'puppetlabs_repo' %>
 <%= snippet 'puppet_setup' %>
 <% end -%>
 

--- a/snippets/epel.erb
+++ b/snippets/epel.erb
@@ -1,6 +1,10 @@
 <%#
 kind: snippet
 name: epel
-%>
-
-su -c 'rpm -Uvh <%= @host.os.medium_uri(@host, "http://dl.fedoraproject.org/pub/epel/epel-release-latest-#{@host.operatingsystem.major}.noarch.rpm") %>'
+-%>
+<%
+http_proxy = @host.params['http-proxy'] ? " --httpproxy #{@host.params['http-proxy']}" : nil
+http_port  = @host.params['http-proxy-port'] ? " --httpport #{@host.params['http-proxy-port']}" : nil
+os_major   = @host.operatingsystem.major.to_i
+-%>
+rpm -Uvh<%= http_proxy %><%= http_port %> https://dl.fedoraproject.org/pub/epel/epel-release-latest-<%= os_major %>.noarch.rpm

--- a/snippets/puppetlabs_repo.erb
+++ b/snippets/puppetlabs_repo.erb
@@ -1,0 +1,39 @@
+<%#
+kind: snippet
+name: puppetlabs_repo
+-%>
+<%
+http_proxy   = @host.params['http-proxy'] ? " --httpproxy #{@host.params['http-proxy']}" : nil
+http_port    = @host.params['http-proxy-port'] ? " --httpport #{@host.params['http-proxy-port']}" : nil
+proxy_uri    = @host.params['http-proxy'] ? "http://#{@host.params['http-proxy']}:#{@host.params['http-proxy-port']}" : nil
+proxy_string = proxy_uri ? " -e https_proxy=#{proxy_uri}/" : ''
+os_family = @host.operatingsystem.family
+os_major  = @host.operatingsystem.major.to_i
+os_name   = @host.operatingsystem.name
+
+if os_family == 'Redhat'
+  repo_host = 'yum.puppetlabs.com'
+  if os_name == 'Fedora'
+    repo_os = 'fedora'
+  else
+    repo_os = 'el'
+  end
+elsif os_family == 'Debian'
+  repo_host = 'apt.puppetlabs.com'
+  repo_os = @host.operatingsystem.release_name
+end
+
+if @host.param_true?('enable-puppetlabs-repo')
+  repo_name = 'puppetlabs-release'
+elsif @host.param_true?('enable-puppetlabs-pc1-repo')
+  repo_name = 'puppetlabs-release-pc1'
+end
+-%>
+<% if repo_name -%>
+<% if os_family == 'Redhat' -%>
+rpm -Uvh<%= http_proxy %><%= http_port %> https://<%= repo_host %>/<%= repo_name %>-<%= repo_os %>-<%= os_major %>.noarch.rpm
+<% elsif os_family == 'Debian' -%>
+wget -O /tmp/<%= repo_name %>-<%= repo_os %>.deb<%= proxy_string %> https://<%= repo_host %>/<%= repo_name %>-<%= repo_os %>.deb
+dpkg -i /tmp/<%= repo_name %>-<%= repo_os %>.deb
+<% end -%>
+<% end -%>


### PR DESCRIPTION
This also updates the epel snippet and introduces a new snippet to set up the puppetlabs repo, which was lifted form the Kickstart finish.  
The puppetlabs repo only supports fadora and centos.  It needs to also support debain/ubuntu.
Any other templates have these shell commands for debian?
