### PR TITLE
Rename selinux parameter

### DIFF
--- a/kickstart/provision.erb
+++ b/kickstart/provision.erb
@@ -8,7 +8,7 @@ oses:
 <%#
 This template accepts the following parameters:
 - lang: string (default="en_US.UTF-8")
-- selinux: string (default="enforcing")
+- selinux-mode: string (default="enforcing")
 - keyboard: string (default="us")
 - time-zone: string (default="UTC")
 - http-proxy: string (default="")
@@ -38,7 +38,7 @@ This template accepts the following parameters:
 install
 <%= @mediapath %><%= proxy_string %>
 lang <%= @host.params['lang'] || 'en_US.UTF-8' %>
-selinux --<%= @host.params['selinux'] || 'enforcing' %>
+selinux --<%= @host.params['selinux-mode'] || @host.params['selinux'] || 'enforcing' %>
 keyboard <%= @host.params['keyboard'] || 'us' %>
 skipx
 

--- a/kickstart/provision_rhel.erb
+++ b/kickstart/provision_rhel.erb
@@ -7,7 +7,7 @@ oses:
 <%#
 This template accepts the following parameters:
 - lang: string (default="en_US.UTF-8")
-- selinux: string (default="enforcing")
+- selinux-mode: string (default="enforcing")
 - keyboard: string (default="us")
 - time-zone: string (default="UTC")
 - http-proxy: string (default="")
@@ -36,7 +36,7 @@ This template accepts the following parameters:
 install
 <%= @mediapath %><%= proxy_string %>
 lang <%= @host.params['lang'] || 'en_US.UTF-8' %>
-selinux --<%= @host.params['selinux'] || 'enforcing' %>
+selinux --<%= @host.params['selinux-mode'] || @host.params['selinux'] || 'enforcing' %>
 keyboard <%= @host.params['keyboard'] || 'us' %>
 skipx
 


### PR DESCRIPTION
`selinux` is a core fact that returns a boolean.
https://docs.puppet.com/facter/latest/core_facts.html#selinux

If also set as a parameter in Foreman, it becomes the output of the ENC
and overrides the true/false returned by facter breaking puppet modules
including theforeman/foreman that uses a `str2bool($::selinux)`
expression.

https://github.com/theforeman/puppet-foreman/blob/5.2.0/manifests/install.pp#L23

`selinux-mode` is hopefully a good choice for the rename.  It doesn't
conflict with any other core fact such as
https://docs.puppet.com/facter/latest/core_facts.html#selinuxconfigmode
or
https://docs.puppet.com/facter/latest/core_facts.html#selinuxcurrentmode
