### PR TITLE
Fedora 23 and above installs dnf instead of yum

### DIFF
--- a/kickstart/finish.erb
+++ b/kickstart/finish.erb
@@ -38,7 +38,11 @@ echo "updating system time"
 <% end -%>
 
 # update all the base packages from the updates repository
-yum -t -y update
+if [ -f /usr/bin/dnf ]; then
+  dnf -y update
+else
+  yum -t -y update
+fi
 
 <%= snippet('remote_execution_ssh_keys') %>
 

--- a/kickstart/provision.erb
+++ b/kickstart/provision.erb
@@ -184,7 +184,11 @@ echo 'proxy = <%= proxy_uri %>' >> /etc/yum.conf
 <% end -%>
 
 # update all the base packages from the updates repository
-yum -t -y update
+if [ -f /usr/bin/dnf ]; then
+  dnf -y update
+else
+  yum -t -y update
+fi
 
 <%= snippet('remote_execution_ssh_keys') %>
 

--- a/kickstart/provision_rhel.erb
+++ b/kickstart/provision_rhel.erb
@@ -162,7 +162,11 @@ echo 'proxy = <%= proxy_uri %>' >> /etc/yum.conf
 <% end -%>
 
 # update all the base packages from the updates repository
-yum -t -y update
+if [ -f /usr/bin/dnf ]; then
+  dnf -y update
+else
+  yum -t -y update
+fi
 
 <%= snippet('remote_execution_ssh_keys') %>
 

--- a/snippets/bmc_nic_setup.erb
+++ b/snippets/bmc_nic_setup.erb
@@ -52,7 +52,11 @@ os_family = @host.operatingsystem.family
 
 # Configure BMC interface
 <% if os_family == 'Redhat' %>
-yum -t -y install ipmitool
+if [ -f /usr/bin/dnf ]; then
+  dnf -y install ipmitool
+else
+  yum -t -y install ipmitool
+fi
 <% elsif os_family == 'Freebsd' %>
 pkg install -y ipmitool
 <% elsif os_family == 'Debian' %>

--- a/snippets/puppet_setup.erb
+++ b/snippets/puppet_setup.erb
@@ -29,7 +29,11 @@ apt-get install -y <%= linux_package %>
 <% elsif os_family == 'Freebsd' -%>
 pkg install -y <%= freebsd_package %>
 <% elsif os_family == 'Redhat' -%>
-yum -t -y install <%= linux_package %>
+if [ -f /usr/bin/dnf ]; then
+  dnf -y install <%= linux_package %>
+else
+  yum -t -y install <%= linux_package %>
+fi
 <% end -%>
 
 cat > <%= etc_path %>/puppet.conf << EOF

--- a/snippets/redhat_register.erb
+++ b/snippets/redhat_register.erb
@@ -126,7 +126,11 @@ name: redhat_register
   <% end %>
 <% else %>
   echo "Starting the subscription-manager registration process"
-  yum -t -y install subscription-manager <%= @host.operatingsystem.major.to_i >= 6 ? 'yum-config-manager' : '' %>
+  if [ -f /usr/bin/dnf ]; then
+    dnf -y install subscription-manager <%= @host.operatingsystem.major.to_i >= 6 ? 'yum-config-manager' : '' %>
+  else
+    yum -t -y install subscription-manager <%= @host.operatingsystem.major.to_i >= 6 ? 'yum-config-manager' : '' %>
+  fi
   <% if @host.operatingsystem.major.to_i >= 6  %>
     <% ( enabled_repos = "yum-config-manager --enable #{@host.params['subscription_manager_repos'].gsub(',', ' ')}") if @host.params['subscription_manager_repos'] %>
   <% else %>


### PR DESCRIPTION
With the use of dnf, the yum redirect does not support -t so all the yum install commands fail to work during the kickstart.  To prevent this, this update would use dnf instead of yum wherever we have the -t parameter included.
