### PR TITLE
adds no-daemonize to puppet_run_once

### DIFF
--- a/jobs/ssh/puppet_run_once.erb
+++ b/jobs/ssh/puppet_run_once.erb
@@ -10,4 +10,4 @@ template_inputs:
   input_type: user
   required: false
 %>
-puppet agent --onetime --no-usecacheonfailure <%= input("puppet_options") %>
+puppet agent --onetime --no-usecacheonfailure --no-daemonize <%= input("puppet_options") %>


### PR DESCRIPTION
This pull request adds no-daemonize as default option to the puppet_run_once job, so it will execute the puppet run also if the agent already runs instead of silently failing during pid creation.
