### PR TITLE
Allow users to set ssh keys param manually

### DIFF
--- a/snippets/remote_execution_ssh_keys.erb
+++ b/snippets/remote_execution_ssh_keys.erb
@@ -26,7 +26,7 @@
 mkdir -p <%= ssh_path %>
 
 cat << EOF >> <%= ssh_path %>/authorized_keys
-<%= @host.params['remote_execution_ssh_keys'].join("\n") %>
+<%= @host.params['remote_execution_ssh_keys'] %>
 EOF
 
 chmod 700 <%= ssh_path %>


### PR DESCRIPTION
To be merged after #16107 is fixed in REX - https://github.com/theforeman/foreman_remote_execution/pull/199
