### PR TITLE
Allow setting reboot strategy

### DIFF
--- a/coreos/README.md
+++ b/coreos/README.md
@@ -2,11 +2,12 @@
 
 The templates use some Host Parameters to contol the flow of the template. These are:
 
-* install-disk: What device to install to (default: /dev/sda | /dev/vda)
-* ssh_authorized_keys: add public SSH keys which will be authorized for the core user. You can specify multiple SSH keys seperated with a "," (default: empty)
-* etcd_discovery_url: provision a discovery token for etcd to allow a simple cluster deployment. You can get a new discovery token at [https://discovery.etcd.io/new](https://discovery.etcd.io/new). This parameter is used in the [coreos_cloudconfig snippet](https://github.com/theforeman/community-templates/blob/develop/snippets/coreos_cloudconfig.erb). (default: empty)
-* expose_docker_socket: if you want to have an exposed Docker TCP socket set this to "true"
-* enable_etcd: if you don't require the etcd (and fleet) service, set this to "false" (default: true)
+- install-disk: What device to install to (default: /dev/sda | /dev/vda)
+- ssh_authorized_keys: add public SSH keys which will be authorized for the core user. You can specify multiple SSH keys seperated with a "," (default: empty)
+- etcd_discovery_url: provision a discovery token for etcd to allow a simple cluster deployment. You can get a new discovery token at <https://discovery.etcd.io/new>. This parameter is used in the [coreos_cloudconfig snippet](https://github.com/theforeman/community-templates/blob/develop/snippets/coreos_cloudconfig.erb). (default: empty)
+- expose_docker_socket: if you want to have an exposed Docker TCP socket set this to "true"
+- enable_etcd: if you don't require the etcd (and fleet) service, set this to "false" (default: true)
+- reboot-strategy: set the reboot-strategy for CoreOS, for more information have a look at the official [documentation](https://coreos.com/os/docs/latest/update-strategies.html)
 
 If you don't add any SSH keys you can login with the core user using the root password.
 

--- a/snippets/coreos_cloudconfig.erb
+++ b/snippets/coreos_cloudconfig.erb
@@ -22,6 +22,10 @@ name: coreos_cloudconfig
 -%>
 <% if units > 0 -%>
       coreos:
+<% if @host.params['reboot-strategy'] -%>
+        update:
+          reboot-strategy: <%= @host.params['reboot-strategy'] %>
+<% else -%>
 <% unless @host.param_false?('enable_etcd') -%>
         etcd2:
 <% if @host.params['etcd_discovery_url'] -%>


### PR DESCRIPTION
This PR allows users to set the reboot-strategy of their CoreOS instances for example if a user doesn't want automatic updates/reboots he can set the value to `off`, here is the official documentation for the [reboot-strategy](https://coreos.com/os/docs/latest/update-strategies.html).

I also added this option in the Readme.md
