### PR TITLE
Support Puppet 4 AIO packages on SLES

### DIFF
--- a/autoyast/provision_sles.erb
+++ b/autoyast/provision_sles.erb
@@ -73,7 +73,11 @@ oses:
       <package>lsb-release</package>
       <package>openssh</package>
 <% if puppet_enabled -%>
+<% if @host.param_true?('enable-puppetlabs-pc1-repo') -%>
+      <package>puppet-agent</package>
+<% else -%>
       <package>rubygem-puppet</package>
+<% end -%>
 <% end -%>
 <% if salt_enabled -%>
       <package>salt-minion</package>
@@ -147,6 +151,19 @@ rm /etc/resolv.conf
   <add-on>
     <add_on_products config:type="list">
 <% if puppet_enabled -%>
+<% if @host.param_true?('enable-puppetlabs-pc1-repo') -%>
+    <listentry>
+        <media_url><![CDATA[http://yum.puppetlabs.com/sles/<%= os_major %>/PC1/<%= @host.architecture %>/]]></media_url>
+        <name>puppet</name>
+        <product>puppet</product>
+        <product_dir>/</product_dir>
+        <signature-handling>
+          <accept_file_without_checksum config:type="boolean">true</accept_file_without_checksum>
+          <accept_unsigned_file config:type="boolean">true</accept_unsigned_file>
+          <accept_unknown_gpg_key config:type="boolean">true</accept_unknown_gpg_key>
+        </signature-handling>
+      </listentry>
+<% else -%>
       <listentry>
         <media_url><![CDATA[http://download.opensuse.org/repositories/systemsmanagement:/puppet/SLE_<%= os_major %><%= sles_minor_string %>/]]></media_url>
         <name>systemsmanagement_puppet</name>
@@ -195,6 +212,7 @@ rm /etc/resolv.conf
         <product_dir>/</product_dir>
         <name>SuSE-Linux-SDK</name>
       </listentry>
+<% end -%>
 <% end -%>
 <% end -%>
 <% if salt_enabled -%>

--- a/snippets/puppet.conf.erb
+++ b/snippets/puppet.conf.erb
@@ -3,7 +3,10 @@ kind: snippet
 name: puppet.conf
 %>
 <%
-  if @host.param_true?('enable-puppetlabs-pc1-repo') && (@host.operatingsystem.family == 'Debian' || @host.operatingsystem.family == 'Redhat')
+  os_family = @host.operatingsystem.family
+  os_name   = @host.operatingsystem.name
+
+  if @host.param_true?('enable-puppetlabs-pc1-repo') && (os_family == 'Debian' || os_family == 'Redhat' || os_name == 'SLES')
     var_dir = '/opt/puppetlabs/puppet/cache'
     log_dir = '/var/log/puppetlabs/puppet'
     run_dir = '/var/run/puppetlabs'

--- a/snippets/puppet_setup.erb
+++ b/snippets/puppet_setup.erb
@@ -34,6 +34,10 @@ if [ -f /usr/bin/dnf ]; then
 else
   yum -t -y install <%= linux_package %>
 fi
+<% elsif os_name == 'SLES' && @host.param_true?('enable-puppetlabs-pc1-repo') -%>
+rpmkeys --import http://yum.puppetlabs.com/RPM-GPG-KEY-puppetlabs
+rpmkeys --import http://yum.puppetlabs.com/RPM-GPG-KEY-puppet
+<%= bin_path %>/puppet resource service puppet enable=true
 <% end -%>
 
 cat > <%= etc_path %>/puppet.conf << EOF


### PR DESCRIPTION
Because of SLES brokenness (see e.g. puppetlabs/puppetlabs-release#80) the RPM keys have to get imported in an extra step.
