### PR TITLE
Fixes #16882 - fixed absolute path for Grub1 kickstart

### DIFF
--- a/kickstart/PXEGrub.erb
+++ b/kickstart/PXEGrub.erb
@@ -14,12 +14,12 @@ timeout=<%= @host.params['loader_timeout'] || 10 %>
 title <%= template_name %>
   root (nd)
   <% if @host.operatingsystem.name.match(/.*atomic.*/i) -%>
-  kernel (nd)/<%= @kernel %> ks=<%= foreman_url('provision') %> repo=<%= @host.operatingsystem.medium_uri(@host) %> ks.device=bootif network ks.sendmac <%= pxe_kernel_options %>
+  kernel (nd)/../<%= @kernel %> ks=<%= foreman_url('provision') %> repo=<%= @host.operatingsystem.medium_uri(@host) %> ks.device=bootif network ks.sendmac <%= pxe_kernel_options %>
   <% elsif @host.operatingsystem.name == 'Fedora' and @host.operatingsystem.major.to_i > 16 -%>
-  kernel (nd)/<%= @kernel %> ks=<%= foreman_url('provision') %> ks.device=bootif network ks.sendmac <%= pxe_kernel_options %>
+  kernel (nd)/../<%= @kernel %> ks=<%= foreman_url('provision') %> ks.device=bootif network ks.sendmac <%= pxe_kernel_options %>
   <% elsif @host.operatingsystem.name != 'Fedora' and @host.operatingsystem.major.to_i >= 7 -%>
-  kernel (nd)/<%= @kernel %> ks=<%= foreman_url('provision') %> network ks.sendmac <%= pxe_kernel_options %>
+  kernel (nd)/../<%= @kernel %> ks=<%= foreman_url('provision') %> network ks.sendmac <%= pxe_kernel_options %>
   <% else -%>
-  kernel (nd)/<%= @kernel %> ks=<%= foreman_url('provision') %> ksdevice=bootif network kssendmac <%= pxe_kernel_options %>
+  kernel (nd)/../<%= @kernel %> ks=<%= foreman_url('provision') %> ksdevice=bootif network kssendmac <%= pxe_kernel_options %>
   <% end -%>
-  initrd (nd)/<%= @initrd %>
+  initrd (nd)/../<%= @initrd %>


### PR DESCRIPTION
Grub1 was giving this error

http://storage7.static.itmages.com/i/16/1012/h_1476270469_9345664_e3371f8da3.png

Unfortunately Grub1 does not allow relative paths like Grub2 and errors out
with `Filename must be either an absolute path or a blocklist`. Therefore the
kernel/image lines must be written this way.
