### PR TITLE
Disable OEL7's mysql boot media repo

### DIFF
--- a/kickstart/provision.erb
+++ b/kickstart/provision.erb
@@ -94,6 +94,10 @@ repo --name=puppetlabs-pc1 --baseurl=http://yum.puppetlabs.com/el/<%= @host.oper
 <% end -%>
 <% end -%>
 
+<% if @host.operatingsystem.name == 'OracleLinux' && os_major == 7 -%>
+repo --name="Server-Mysql"
+<% end -%>
+
 <% if @host.operatingsystem.name == 'Fedora' and os_major <= 16 -%>
 # Bootloader exception for Fedora 16:
 bootloader --append="<%= @host.params['bootloader-append'] || 'nofb quiet splash=quiet' %> <%=ks_console%>" <%= grub_pass %>


### PR DESCRIPTION
Installation media for OEL7.2 includes out of date mysql packages in
`addons/Mysql`.  This repo is automatically enabled during kickstart
installation, and `mysql-communitity-libs` gets installed as a
dependency of `postfix`. `mysql-communitity-libs` is not updated during
a `yum update` as it doesn't exist in
http://public-yum.oracle.com/repo/OracleLinux/OL7/latest/x86_64/index.html
and
http://public-yum.oracle.com/repo/OracleLinux/OL7/MySQL56/x86_64/index.html
is not configured in `/etc/yum.repos.d`.

This commit disables this problematic boot media repository.  As
`mysql-communitity-libs` is no longer available to the installer,
`mariadb-libs` get installed instead to satisfy `postfix`.

This doesn't prevent users from later choosing to install mysql by
enabling one of the `mysql` repos from
http://public-yum.oracle.com/oracle-linux-7.html and doing a `yum
install mysql`