### PR TITLE
coreos_cloudconfig missing end

### DIFF
--- a/snippets/coreos_cloudconfig.erb
+++ b/snippets/coreos_cloudconfig.erb
@@ -25,7 +25,7 @@ name: coreos_cloudconfig
 <% if @host.params['reboot-strategy'] -%>
         update:
           reboot-strategy: <%= @host.params['reboot-strategy'] %>
-<% else -%>
+<% end -%>
 <% unless @host.param_false?('enable_etcd') -%>
         etcd2:
 <% if @host.params['etcd_discovery_url'] -%>


### PR DESCRIPTION
The latest commit introduced some conditions in this file without the
corresponding end.