### PR TITLE
Don't install authorized_keys if user missing

### DIFF
--- a/snippets/remote_execution_ssh_keys.erb
+++ b/snippets/remote_execution_ssh_keys.erb
@@ -15,25 +15,34 @@
 # SSH key is in remote_execution_ssh_keys, you can SSH into a host. This only
 # works in combination with Remote Execution plugin.
 
-# A personal recomendation: create a global parameter remote_execution_ssh_keys
-# and put your keys there, so that you can access any newly provisioned host
-# without having to set up the parameter on every host or host group.
-
+# The Remote Execution plugin queries smart proxies to build the
+# remote_execution_ssh_keys array which is then made available to this template
+# via the host's parameters. There is currently no way of supplying this
+# parameter manually.
+# See http://projects.theforeman.org/issues/16107 for details.
 
 <% if !@host.params['remote_execution_ssh_keys'].blank? %>
 <% ssh_user = @host.params['remote_execution_ssh_user'] || 'root' %>
+
+user_exists=false
+getent passwd <%= ssh_user %> >/dev/null 2>&1 && user_exists=true
+
+if $user_exists; then
 <% ssh_path = "~#{ssh_user}/.ssh" %>
 
-mkdir -p <%= ssh_path %>
+  mkdir -p <%= ssh_path %>
 
-cat << EOF >> <%= ssh_path %>/authorized_keys
+  cat << EOF >> <%= ssh_path %>/authorized_keys
 <%= @host.params['remote_execution_ssh_keys'].join("\n") %>
 EOF
 
-chmod 700 <%= ssh_path %>
-chmod 600 <%= ssh_path %>/authorized_keys
-chown -R <%= "#{ssh_user}:" %> <%= ssh_path %>
+  chmod 700 <%= ssh_path %>
+  chmod 600 <%= ssh_path %>/authorized_keys
+  chown -R <%= "#{ssh_user}:" %> <%= ssh_path %>
 
-# Restore SELinux context with restorecon, if it's available:
-command -v restorecon && restorecon -RvF <%= ssh_path %> || true
+  # Restore SELinux context with restorecon, if it's available:
+  command -v restorecon && restorecon -RvF <%= ssh_path %> || true
+else
+  echo 'The remote_execution_ssh_user does not exist.  remote_execution_ssh_keys snippet will not install keys'
+fi
 <% end %>


### PR DESCRIPTION
If the `remote_execution_ssh_user` doesn't exist, then skip trying to
install the `remote_execution_ssh_keys` as `authorized_keys`.

This prevents erroneously creating a `/~some_user/.ssh/authorized_keys`
file.

Also updated the comments that were at best misleading.