### PR TITLE
Disable Certificate Verification on preseed/late_command to Inform Fo…

### DIFF
--- a/preseed/provision.erb
+++ b/preseed/provision.erb
@@ -155,4 +155,6 @@ d-i grub-installer/bootdev string default
 <% end -%>
 d-i finish-install/reboot_in_progress note
 
-d-i preseed/late_command string wget -Y off <%= @static ? "'#{foreman_url('finish')}&static=true'" : foreman_url('finish') %> -O /target/tmp/finish.sh && in-target chmod +x /tmp/finish.sh && in-target /tmp/finish.sh
+# Disable Certificate Check on Inform Foreman
+#d-i preseed/late_command string wget -Y off <%= @static ? "'#{foreman_url('finish')}&static=true'" : foreman_url('finish') %> -O /target/tmp/finish.sh && in-target chmod +x /tmp/finish.sh && in-target /tmp/finish.sh
+d-i preseed/late_command string wget -Y off --no-proxy --quiet --output-document=/dev/null --no-check-certificate <%= @static ? "'#{foreman_url('finish')}&static=true'" : foreman_url('finish') %> -O /target/tmp/finish.sh && in-target chmod +x /tmp/finish.sh && in-target /tmp/finish.sh


### PR DESCRIPTION
…reman

This fails when using self signed certificates i.e.: the wget switches should be similar to what is in the finish:

--no-proxy --quiet --output-document=/dev/null --no-check-certificate