### PR TITLE
Added repo-mirror for puppet and epel repos

### DIFF
--- a/kickstart/provision.erb
+++ b/kickstart/provision.erb
@@ -23,6 +23,7 @@ This template accepts the following parameters:
 - disable-firewall: boolean (default=false)
 - package_upgrade: boolean (default=true)
 - disable-uek: boolean (default=false)
+- repo-mirror: string (default="")
 %>
 <%
   rhel_compatible = @host.operatingsystem.family == 'Redhat' && @host.operatingsystem.name != 'Fedora'
@@ -73,24 +74,28 @@ realm join --one-time-password='<%= @host.otp || "$HOST[OTP]" %>' <%= @host.real
 repo --name=fedora-everything --mirrorlist=https://mirrors.fedoraproject.org/metalink?repo=fedora-<%= @host.operatingsystem.major %>&arch=<%= @host.architecture %><%= proxy_string %>
 <% if puppet_enabled -%>
 <% if @host.param_true?('enable-puppetlabs-repo') -%>
-repo --name=puppetlabs-products --baseurl=http://yum.puppetlabs.com/fedora/f<%= @host.operatingsystem.major %>/products/<%= @host.architecture %><%= proxy_string %>
-repo --name=puppetlabs-deps --baseurl=http://yum.puppetlabs.com/fedora/f<%= @host.operatingsystem.major %>/dependencies/<%= @host.architecture %><%= proxy_string %>
+repo --name=puppetlabs-products --baseurl=<%= @host.params['repo-mirror'] || 'http://yum.puppetlabs.com' %>/fedora/f<%= @host.operatingsystem.major %>/products/<%= @host.architecture %><%= proxy_string %>
+repo --name=puppetlabs-deps --baseurl=<%= @host.params['repo-mirror'] || 'http://yum.puppetlabs.com' %>/fedora/f<%= @host.operatingsystem.major %>/dependencies/<%= @host.architecture %><%= proxy_string %>
 <% end -%>
 <% if @host.param_true?('enable-puppetlabs-pc1-repo') -%>
-repo --name=puppetlabs-pc1 --baseurl=http://yum.puppetlabs.com/fedora/f<%= @host.operatingsystem.major %>/PC1/<%= @host.architecture %><%= proxy_string %>
+repo --name=puppetlabs-pc1 --baseurl=<%= @host.params['repo-mirror'] || 'http://yum.puppetlabs.com' %>/fedora/f<%= @host.operatingsystem.major %>/PC1/<%= @host.architecture %><%= proxy_string %>
 <% end -%>
 <% end -%>
 <% elsif rhel_compatible && os_major > 4 -%>
 <% unless @host.param_false?('enable-epel') -%>
+<% if @host.params['repo-mirror'] %>
+repo --name="EPEL" --mirrorlist=<%= @host.params['repo-mirror'] %>/pub/epel/<%= @host.operatingsystem.major %>/<%= @host.architecture %><%= proxy_string %>
+<% else -%>
 repo --name="EPEL" --mirrorlist=https://mirrors.fedoraproject.org/metalink?repo=epel-<%= @host.operatingsystem.major %>&arch=<%= @host.architecture %><%= proxy_string %>
+<% end -%>
 <% end -%>
 <% if puppet_enabled -%>
 <% if @host.param_true?('enable-puppetlabs-repo') -%>
-repo --name=puppetlabs-products --baseurl=http://yum.puppetlabs.com/el/<%= @host.operatingsystem.major %>/products/<%= @host.architecture %><%= proxy_string %>
-repo --name=puppetlabs-deps --baseurl=http://yum.puppetlabs.com/el/<%= @host.operatingsystem.major %>/dependencies/<%= @host.architecture %><%= proxy_string %>
+repo --name=puppetlabs-products --baseurl=<%= @host.params['repo-mirror'] || 'http://yum.puppetlabs.com' %>/el/<%= @host.operatingsystem.major %>/products/<%= @host.architecture %><%= proxy_string %>
+repo --name=puppetlabs-deps --baseurl=<%= @host.params['repo-mirror'] || 'http://yum.puppetlabs.com' %>/el/<%= @host.operatingsystem.major %>/dependencies/<%= @host.architecture %><%= proxy_string %>
 <% end -%>
 <% if @host.param_true?('enable-puppetlabs-pc1-repo') -%>
-repo --name=puppetlabs-pc1 --baseurl=http://yum.puppetlabs.com/el/<%= @host.operatingsystem.major %>/PC1/<%= @host.architecture %><%= proxy_string %>
+repo --name=puppetlabs-pc1 --baseurl=<%= @host.params['repo-mirror'] || 'http://yum.puppetlabs.com' %>/el/<%= @host.operatingsystem.major %>/PC1/<%= @host.architecture %><%= proxy_string %>
 <% end -%>
 <% end -%>
 <% end -%>
@@ -137,10 +142,10 @@ epel-release
 <% end -%>
 <% if puppet_enabled -%>
 <%= @host.param_true?('enable-puppetlabs-pc1-repo') ? 'puppet-agent' : 'puppet' %>
-<% if @host.param_true?('enable-puppetlabs-repo') -%>
+<% if @host.param_true?('enable-puppetlabs-repo') && !@host.params['repo-mirror'] -%>
 puppetlabs-release
 <% end -%>
-<% if @host.param_true?('enable-puppetlabs-pc1-repo') -%>
+<% if @host.param_true?('enable-puppetlabs-pc1-repo') && !@host.params['repo-mirror'] -%>
 puppetlabs-release-pc1
 <% end -%>
 <% end -%>

--- a/kickstart/provision_rhel.erb
+++ b/kickstart/provision_rhel.erb
@@ -21,6 +21,7 @@ This template accepts the following parameters:
 - bootloader-append: string (default="nofb quiet splash=quiet")
 - disable-firewall: boolean (default=false)
 - package_upgrade: boolean (default=true)
+- repo-mirror: string (default="")
 %>
 <%
   os_major = @host.operatingsystem.major.to_i
@@ -68,15 +69,19 @@ realm join --one-time-password='<%= @host.otp || "$HOST[OTP]" %>' <%= @host.real
 
 <% if os_major > 4 -%>
 <% unless @host.param_false?('enable-epel') -%>
+<% if @host.params['repo-mirror'] %>
+repo --name="EPEL" --mirrorlist=<%= @host.params['repo-mirror'] %>/pub/epel/<%= @host.operatingsystem.major %>/<%= @host.architecture %><%= proxy_string %>
+<% else -%>
 repo --name="EPEL" --mirrorlist=https://mirrors.fedoraproject.org/metalink?repo=epel-<%= @host.operatingsystem.major %>&arch=<%= @host.architecture %><%= proxy_string %>
+<% end -%>
 <% end -%>
 <% if puppet_enabled -%>
 <% if @host.param_true?('enable-puppetlabs-repo') -%>
-repo --name=puppetlabs-products --baseurl=http://yum.puppetlabs.com/el/<%= @host.operatingsystem.major %>/products/<%= @host.architecture %><%= proxy_string %>
-repo --name=puppetlabs-deps --baseurl=http://yum.puppetlabs.com/el/<%= @host.operatingsystem.major %>/dependencies/<%= @host.architecture %><%= proxy_string %>
+repo --name=puppetlabs-products --baseurl=<%= @host.params['repo-mirror'] || 'http://yum.puppetlabs.com' %>/el/<%= @host.operatingsystem.major %>/products/<%= @host.architecture %><%= proxy_string %>
+repo --name=puppetlabs-deps --baseurl=<%= @host.params['repo-mirror'] || 'http://yum.puppetlabs.com' %>/el/<%= @host.operatingsystem.major %>/dependencies/<%= @host.architecture %><%= proxy_string %>
 <% end -%>
 <% if @host.param_true?('enable-puppetlabs-pc1-repo') -%>
-repo --name=puppetlabs-pc1 --baseurl=http://yum.puppetlabs.com/el/<%= @host.operatingsystem.major %>/PC1/<%= @host.architecture %><%= proxy_string %>
+repo --name=puppetlabs-pc1 --baseurl=<%= @host.params['repo-mirror'] || 'http://yum.puppetlabs.com' %>/el/<%= @host.operatingsystem.major %>/PC1/<%= @host.architecture %><%= proxy_string %>
 <% end -%>
 <% end -%>
 <% end -%>


### PR DESCRIPTION
Hi!

we have a repo mirror because our machines does not have internet access. 

Here is a patch add the variable repo-mirror for RHEL based systems.