### PR TITLE
Fix preseed make user typo

### DIFF
--- a/preseed/provision.erb
+++ b/preseed/provision.erb
@@ -77,7 +77,7 @@ d-i clock-setup/ntp-server string <%= @host.params['ntp-server'] || '0.debian.po
 # User settings
 d-i passwd/root-password-crypted password <%= root_pass %>
 user-setup-udeb passwd/root-login boolean true
-d-i passwd passwd/make-user boolean false
+d-i passwd/make-user boolean false
 user-setup-udeb passwd/make-user boolean false
 
 <% repos = 0 %>


### PR DESCRIPTION
- Typo in d-i line to set `passwd/make-user` false
  - ref: https://www.debian.org/releases/wheezy/example-preseed.txt
  - ref: https://help.ubuntu.com/lts/installation-guide/example-preseed.txt
- Resolves GH-328