### PR TITLE
kickstart finish: root_pass may be nil

### DIFF
--- a/kickstart/finish.erb
+++ b/kickstart/finish.erb
@@ -27,7 +27,7 @@ service network restart
   chef_enabled = @host.respond_to?(:chef_proxy) && @host.chef_proxy
 %>
 
-<% if @host.provision_method == 'image' && !root_pass.empty? -%>
+<% if @host.provision_method == 'image' && root_pass.present? -%>
 # Install the root password
 echo 'root:<%= root_pass -%>' | /usr/sbin/chpasswd -e
 <% end -%>


### PR DESCRIPTION
This commit fixes an issue, where `empty?` is called on root_pass which
has a nil value. This causes the template rendering to fail as `empty?`
is undefined for NilClass.