### PR TITLE
enable net.ifnames=1 to allow biosdevnames

### DIFF
--- a/provisioning_templates/snippet/pxegrub2_discovery.erb
+++ b/provisioning_templates/snippet/pxegrub2_discovery.erb
@@ -3,6 +3,6 @@ kind: snippet
 name: pxegrub2_discovery
 -%>
 menuentry 'Foreman Discovery Image' {
-  linuxefi boot/fdi-image/vmlinuz0 rootflags=loop root=live:/fdi.iso rootfstype=auto ro rd.live.image acpi=force rd.luks=0 rd.md=0 rd.dm=0 rd.lvm=0 rd.bootif=0 rd.neednet=0 nomodeset proxy.url=<%= foreman_server_url %> proxy.type=foreman BOOTIF=01-$net_default_mac
+  linuxefi boot/fdi-image/vmlinuz0 rootflags=loop root=live:/fdi.iso rootfstype=auto ro rd.live.image acpi=force rd.luks=0 rd.md=0 rd.dm=0 rd.lvm=0 rd.bootif=0 rd.neednet=0 nomodeset net.ifnames=<%= @host.param_true?('disable-net-ifnames') ? '0' : '1' %> proxy.url=<%= foreman_server_url %> proxy.type=foreman BOOTIF=01-$net_default_mac
   initrdefi boot/fdi-image/initrd0.img
 }

--- a/provisioning_templates/snippet/pxegrub2_discovery.erb
+++ b/provisioning_templates/snippet/pxegrub2_discovery.erb
@@ -3,6 +3,6 @@ kind: snippet
 name: pxegrub2_discovery
 -%>
 menuentry 'Foreman Discovery Image' {
-  linuxefi boot/fdi-image/vmlinuz0 rootflags=loop root=live:/fdi.iso rootfstype=auto ro rd.live.image acpi=force rd.luks=0 rd.md=0 rd.dm=0 rd.lvm=0 rd.bootif=0 rd.neednet=0 nomodeset net.ifnames=<%= @host.param_true?('disable-net-ifnames') ? '0' : '1' %> proxy.url=<%= foreman_server_url %> proxy.type=foreman BOOTIF=01-$net_default_mac
+  linuxefi boot/fdi-image/vmlinuz0 rootflags=loop root=live:/fdi.iso rootfstype=auto ro rd.live.image acpi=force rd.luks=0 rd.md=0 rd.dm=0 rd.lvm=0 rd.bootif=0 rd.neednet=0 nomodeset net.ifnames=<%= @host.param_true?('disable-net-ifnames') ? '0' : '1' rescue '1' %> proxy.url=<%= foreman_server_url %> proxy.type=foreman BOOTIF=01-$net_default_mac
   initrdefi boot/fdi-image/initrd0.img
 }

--- a/provisioning_templates/snippet/pxegrub2_discovery.erb
+++ b/provisioning_templates/snippet/pxegrub2_discovery.erb
@@ -2,7 +2,12 @@
 kind: snippet
 name: pxegrub2_discovery
 -%>
+<%#
+discovery image is based on CentOS/RHEL and therefor it is affected by https://bugzilla.redhat.com/show_bug.cgi?id=1259015.
+In short, before RHEL 7.2 virtio driver didn't have the new persistent naming scheme, causing interfaces to be named eth0, eth1, etc..
+If you want to enable the new persistent naming scheme and get inteface names like ens3, add net.ifnames=1 to the linuxefi line below.
+-%>
 menuentry 'Foreman Discovery Image' {
-  linuxefi boot/fdi-image/vmlinuz0 rootflags=loop root=live:/fdi.iso rootfstype=auto ro rd.live.image acpi=force rd.luks=0 rd.md=0 rd.dm=0 rd.lvm=0 rd.bootif=0 rd.neednet=0 nomodeset net.ifnames=<%= @host.param_true?('disable-net-ifnames') ? '0' : '1' rescue '1' %> proxy.url=<%= foreman_server_url %> proxy.type=foreman BOOTIF=01-$net_default_mac
+  linuxefi boot/fdi-image/vmlinuz0 rootflags=loop root=live:/fdi.iso rootfstype=auto ro rd.live.image acpi=force rd.luks=0 rd.md=0 rd.dm=0 rd.lvm=0 rd.bootif=0 rd.neednet=0 nomodeset proxy.url=<%= foreman_server_url %> proxy.type=foreman BOOTIF=01-$net_default_mac
   initrdefi boot/fdi-image/initrd0.img
 }

--- a/provisioning_templates/snippet/pxegrub_discovery.erb
+++ b/provisioning_templates/snippet/pxegrub_discovery.erb
@@ -4,5 +4,5 @@ name: pxegrub_discovery
 -%>
 # http://projects.theforeman.org/issues/15997
 title Foreman Discovery Image - not supported with Grub 1.x
-  kernel boot/fdi-image/vmlinuz0 rootflags=loop root=live:/fdi.iso rootfstype=auto ro rd.live.image acpi=force rd.luks=0 rd.md=0 rd.dm=0 rd.lvm=0 rd.bootif=0 rd.neednet=0 nomodeset proxy.url=<%= foreman_server_url %> proxy.type=foreman BOOTIF=01-$net_default_mac
+  kernel boot/fdi-image/vmlinuz0 rootflags=loop root=live:/fdi.iso rootfstype=auto ro rd.live.image acpi=force rd.luks=0 rd.md=0 rd.dm=0 rd.lvm=0 rd.bootif=0 rd.neednet=0 nomodeset net.ifnames=<%= @host.param_true?('disable-net-ifnames') ? '0' : '1' %> proxy.url=<%= foreman_server_url %> proxy.type=foreman BOOTIF=01-$net_default_mac
   initrd boot/fdi-image/initrd0.img

--- a/provisioning_templates/snippet/pxegrub_discovery.erb
+++ b/provisioning_templates/snippet/pxegrub_discovery.erb
@@ -4,5 +4,5 @@ name: pxegrub_discovery
 -%>
 # http://projects.theforeman.org/issues/15997
 title Foreman Discovery Image - not supported with Grub 1.x
-  kernel boot/fdi-image/vmlinuz0 rootflags=loop root=live:/fdi.iso rootfstype=auto ro rd.live.image acpi=force rd.luks=0 rd.md=0 rd.dm=0 rd.lvm=0 rd.bootif=0 rd.neednet=0 nomodeset net.ifnames=<%= @host.param_true?('disable-net-ifnames') ? '0' : '1' %> proxy.url=<%= foreman_server_url %> proxy.type=foreman BOOTIF=01-$net_default_mac
+  kernel boot/fdi-image/vmlinuz0 rootflags=loop root=live:/fdi.iso rootfstype=auto ro rd.live.image acpi=force rd.luks=0 rd.md=0 rd.dm=0 rd.lvm=0 rd.bootif=0 rd.neednet=0 nomodeset net.ifnames=<%= @host.param_true?('disable-net-ifnames') ? '0' : '1' rescue '1' %> proxy.url=<%= foreman_server_url %> proxy.type=foreman BOOTIF=01-$net_default_mac
   initrd boot/fdi-image/initrd0.img

--- a/provisioning_templates/snippet/pxegrub_discovery.erb
+++ b/provisioning_templates/snippet/pxegrub_discovery.erb
@@ -2,7 +2,12 @@
 kind: snippet
 name: pxegrub_discovery
 -%>
+<%#
+discovery image is based on CentOS/RHEL and therefor it is affected by https://bugzilla.redhat.com/show_bug.cgi?id=1259015.
+In short, before RHEL 7.2 virtio driver didn't have the new persistent naming scheme, causing interfaces to be named eth0, eth1, etc..
+If you want to enable the new persistent naming scheme and get inteface names like ens3, add net.ifnames=1 to the kernel line below.
+-%>
 # http://projects.theforeman.org/issues/15997
 title Foreman Discovery Image - not supported with Grub 1.x
-  kernel boot/fdi-image/vmlinuz0 rootflags=loop root=live:/fdi.iso rootfstype=auto ro rd.live.image acpi=force rd.luks=0 rd.md=0 rd.dm=0 rd.lvm=0 rd.bootif=0 rd.neednet=0 nomodeset net.ifnames=<%= @host.param_true?('disable-net-ifnames') ? '0' : '1' rescue '1' %> proxy.url=<%= foreman_server_url %> proxy.type=foreman BOOTIF=01-$net_default_mac
+  kernel boot/fdi-image/vmlinuz0 rootflags=loop root=live:/fdi.iso rootfstype=auto ro rd.live.image acpi=force rd.luks=0 rd.md=0 rd.dm=0 rd.lvm=0 rd.bootif=0 rd.neednet=0 nomodeset proxy.url=<%= foreman_server_url %> proxy.type=foreman BOOTIF=01-$net_default_mac
   initrd boot/fdi-image/initrd0.img

--- a/provisioning_templates/snippet/pxelinux_discovery.erb
+++ b/provisioning_templates/snippet/pxelinux_discovery.erb
@@ -5,5 +5,5 @@ name: pxelinux_discovery
 LABEL discovery
   MENU LABEL Foreman Discovery Image
   KERNEL boot/fdi-image/vmlinuz0
-  APPEND initrd=boot/fdi-image/initrd0.img rootflags=loop root=live:/fdi.iso rootfstype=auto ro rd.live.image acpi=force rd.luks=0 rd.md=0 rd.dm=0 rd.lvm=0 rd.bootif=0 rd.neednet=0 nomodeset proxy.url=<%= foreman_server_url %> proxy.type=foreman
+  APPEND initrd=boot/fdi-image/initrd0.img rootflags=loop root=live:/fdi.iso rootfstype=auto ro rd.live.image acpi=force rd.luks=0 rd.md=0 rd.dm=0 rd.lvm=0 rd.bootif=0 rd.neednet=0 nomodeset net.ifnames=<%= @host.param_true?('disable-net-ifnames') ? '0' : '1' %> proxy.url=<%= foreman_server_url %> proxy.type=foreman
   IPAPPEND 2

--- a/provisioning_templates/snippet/pxelinux_discovery.erb
+++ b/provisioning_templates/snippet/pxelinux_discovery.erb
@@ -5,5 +5,5 @@ name: pxelinux_discovery
 LABEL discovery
   MENU LABEL Foreman Discovery Image
   KERNEL boot/fdi-image/vmlinuz0
-  APPEND initrd=boot/fdi-image/initrd0.img rootflags=loop root=live:/fdi.iso rootfstype=auto ro rd.live.image acpi=force rd.luks=0 rd.md=0 rd.dm=0 rd.lvm=0 rd.bootif=0 rd.neednet=0 nomodeset net.ifnames=<%= @host.param_true?('disable-net-ifnames') ? '0' : '1' %> proxy.url=<%= foreman_server_url %> proxy.type=foreman
+  APPEND initrd=boot/fdi-image/initrd0.img rootflags=loop root=live:/fdi.iso rootfstype=auto ro rd.live.image acpi=force rd.luks=0 rd.md=0 rd.dm=0 rd.lvm=0 rd.bootif=0 rd.neednet=0 nomodeset net.ifnames=<%= @host.param_true?('disable-net-ifnames') ? '0' : '1' rescue '1' %> proxy.url=<%= foreman_server_url %> proxy.type=foreman
   IPAPPEND 2

--- a/provisioning_templates/snippet/pxelinux_discovery.erb
+++ b/provisioning_templates/snippet/pxelinux_discovery.erb
@@ -2,8 +2,13 @@
 kind: snippet
 name: pxelinux_discovery
 -%>
+<%#
+discovery image is based on CentOS/RHEL and therefor it is affected by https://bugzilla.redhat.com/show_bug.cgi?id=1259015.
+In short, before RHEL 7.2 virtio driver didn't have the new persistent naming scheme, causing interfaces to be named eth0, eth1, etc..
+If you want to enable the new persistent naming scheme and get inteface names like ens3, add net.ifnames=1 to the APPEND line below.
+-%>
 LABEL discovery
   MENU LABEL Foreman Discovery Image
   KERNEL boot/fdi-image/vmlinuz0
-  APPEND initrd=boot/fdi-image/initrd0.img rootflags=loop root=live:/fdi.iso rootfstype=auto ro rd.live.image acpi=force rd.luks=0 rd.md=0 rd.dm=0 rd.lvm=0 rd.bootif=0 rd.neednet=0 nomodeset net.ifnames=<%= @host.param_true?('disable-net-ifnames') ? '0' : '1' rescue '1' %> proxy.url=<%= foreman_server_url %> proxy.type=foreman
+  APPEND initrd=boot/fdi-image/initrd0.img rootflags=loop root=live:/fdi.iso rootfstype=auto ro rd.live.image acpi=force rd.luks=0 rd.md=0 rd.dm=0 rd.lvm=0 rd.bootif=0 rd.neednet=0 nomodeset proxy.url=<%= foreman_server_url %> proxy.type=foreman
   IPAPPEND 2


### PR DESCRIPTION
In my opinion net.ifnames=1 is a sane default value and should be set if not overridden via 'disable-net-ifnames' parameter.
The reason for my believe is that I feel that more Linux distros are moving towards using biosdevnames like em1, em2, etc.. instead of eth0, eth1.. and this would increase compatibility with newer Linux distributions.