### PR TITLE
Allow ipv6-only interfaces

### DIFF
--- a/provisioning_templates/snippet/kickstart_ifcfg_generic_interface.erb
+++ b/provisioning_templates/snippet/kickstart_ifcfg_generic_interface.erb
@@ -13,15 +13,15 @@ BOOTPROTO="<%= @dhcp ? 'dhcp' : 'none' -%>"
 <%=       "GATEWAY=\"#{@subnet.gateway}\"" %>
 <%-     end -%>
 <%-   end -%>
-<%-   if @interface.ip6.present? -%>
-<%=     "IPV6INIT=yes" %>
-<%=     "IPV6_AUTOCONF=no" %>
-<%=     "IPV6ADDR=#{@interface.ip6}" %>
-<%-     if @subnet6.gateway.present? -%>
-<%=       "IPV6_DEFAULTGW=#{@subnet6.gateway}" %><%= '%$real' if subnet6.gateway.match(/^fe80:/) %>
-<%-     end -%>
-<%=     "IPV6_PEERDNS=no" %>
+<%- end -%>
+<%- if @interface.ip6.present? -%>
+<%=   "IPV6INIT=yes" %>
+<%=   "IPV6_AUTOCONF=no" %>
+<%=   "IPV6ADDR=#{@interface.ip6}" %>
+<%-   if @subnet6.gateway.present? -%>
+<%=     "IPV6_DEFAULTGW=#{@subnet6.gateway}" %><%= '%$real' if subnet6.gateway.match(/^fe80:/) %>
 <%-   end -%>
+<%=   "IPV6_PEERDNS=no" %>
 <%- end -%>
 DEVICE=$real
 <%- unless @interface.virtual? -%>


### PR DESCRIPTION
A generic interface can have an ipv6 address without having an ipv4
address