### PR TITLE
add windows puppet-agent setup and config to puppet snippets

### DIFF
--- a/provisioning_templates/snippet/puppet.conf.erb
+++ b/provisioning_templates/snippet/puppet.conf.erb
@@ -11,6 +11,11 @@ name: puppet.conf
     log_dir = '/var/log/puppetlabs/puppet'
     run_dir = '/var/run/puppetlabs'
     ssl_dir = '/etc/puppetlabs/puppet/ssl'
+  elsif os_family == 'Windows'
+    var_dir = 'C:\ProgramData\PuppetLabs\puppet\cache'
+    log_dir = 'C:\ProgramData\PuppetLabs\puppet\var\log'
+    run_dir = 'C:\ProgramData\PuppetLabs\puppet\var\run'
+    ssl_dir = 'C:\ProgramData\PuppetLabs\puppet\etc\ssl'
   else
     if @host.operatingsystem.family == 'Freebsd'
       var_dir = '/var/puppet'

--- a/provisioning_templates/snippet/puppet_setup.erb
+++ b/provisioning_templates/snippet/puppet_setup.erb
@@ -12,6 +12,10 @@ if os_family == 'Freebsd'
   freebsd_package = @host.param_true?('enable-puppet4') ? 'puppet4' : 'puppet38'
   etc_path = '/usr/local/etc/puppet'
   bin_path = '/usr/local/bin'
+elsif os_family == 'Windows'
+  windows_package = "puppet-agent-#{@host.architecture}-latest.msi"
+  etc_path = 'C:\ProgramData\PuppetLabs\puppet\etc'
+  bin_path = 'C:\Program Files\Puppet Labs\Puppet\bin'
 elsif @host.param_true?('enable-puppetlabs-pc1-repo') || @host.param_true?('enable-puppet4')
   linux_package = 'puppet-agent'
   etc_path = '/etc/puppetlabs/puppet'
@@ -42,11 +46,31 @@ rpmkeys --import http://yum.puppetlabs.com/RPM-GPG-KEY-puppet
 <% if @host.provision_method == 'image' -%>
 /usr/bin/zypper -n install <%= linux_package %>
 <% end -%>
+<% elsif os_family == 'Windows' -%>
+$puppet_agent_msi = "${env:TEMP}\puppet-agent-<%= @host.architecture %>.msi"
+$puppet_install_args = @(
+  '/qn',
+  '/norestart',
+  '/i',
+  "${puppet_agent_msi}",
+  <%- if @host.puppet_ca_server.strip -%>
+  "PUPPET_CA_SERVER=<%= @host.puppet_ca_server %>",
+  <%- end -%>
+  "PUPPET_MASTER_SERVER=<%= @host.puppetmaster %>"
+)
+
+Write-Host "Installing ${puppet_agent_msi} with args ${puppet_install_args}"
+Start-Process 'msiexec.exe' -ArgumentList $puppet_install_args -Wait -NoNewWindow
 <% end -%>
 
+<% if os_family == 'Windows' -%>
+$puppet_conf = @("<%= snippet 'puppet.conf' %>".Replace("`n","`r`n"))
+Out-File -FilePath <%= etc_path %>\puppet.conf -InputObject $puppet_conf
+<% else -%>
 cat > <%= etc_path %>/puppet.conf << EOF
 <%= snippet 'puppet.conf' %>
 EOF
+<% end -%>
 
 <% if os_family == 'Redhat' -%>
 <% if os_major > 6 -%>
@@ -95,6 +119,20 @@ mkdir -p /run/systemd/system
 <% end -%>
 <% end -%>
 # export a custom fact called 'is_installer' to allow detection of the installer environment in Puppet modules
+<% if os_family == 'Windows' -%>
+$env:FACTER_is_installer = $TRUE
+
+# passing a non-existent tag like "no_such_tag" to the puppet agent only initializes the node
+$puppet_agent_args = @(
+  "agent",
+  "--config", "<%= etc_path %>\puppet.conf",
+  "--onetime",
+  <%= @host.param_true?('run-puppet-in-installer') ? '' : '"--tags no_such_tag",' %>
+  <%= @host.puppetmaster.blank? ? '' : "\"--server #{@host.puppetmaster}\"," %>
+  "--no-daemonize"
+)
+Start-Process '<%= bin_path %>\puppet' -ArgumentList $puppet_agent_args -Wait -NoNewWindow
+<% else -%>
 export FACTER_is_installer=true
 # passing a non-existent tag like "no_such_tag" to the puppet agent only initializes the node
 <%= bin_path %>/puppet agent --config <%= etc_path %>/puppet.conf --onetime <%= @host.param_true?('run-puppet-in-installer') ? '' : '--tags no_such_tag' %> <%= @host.puppetmaster.blank? ? '' : "--server #{@host.puppetmaster}" %> --no-daemonize
@@ -102,5 +140,6 @@ export FACTER_is_installer=true
 <%= bin_path %>/puppet resource service puppet enable=true
 <% if @host.provision_method == 'image' -%>
 <%= bin_path %>/puppet resource service puppet ensure=running
+<% end -%>
 <% end -%>
 <% end -%>

--- a/provisioning_templates/snippet/puppetlabs_repo.erb
+++ b/provisioning_templates/snippet/puppetlabs_repo.erb
@@ -7,6 +7,7 @@ http_proxy   = @host.params['http-proxy'] ? " --httpproxy #{@host.params['http-p
 http_port    = @host.params['http-proxy-port'] ? " --httpport #{@host.params['http-proxy-port']}" : nil
 proxy_uri    = @host.params['http-proxy'] ? "http://#{@host.params['http-proxy']}:#{@host.params['http-proxy-port']}" : nil
 proxy_string = proxy_uri ? " -e https_proxy=#{proxy_uri}/" : ''
+proxy_string_bits = proxy_uri ? " -ProxyUsage Override -ProxyList #{proxy_uri}" : ''
 os_family = @host.operatingsystem.family
 os_major  = @host.operatingsystem.major.to_i
 os_name   = @host.operatingsystem.name
@@ -24,6 +25,9 @@ elsif os_family == 'Suse'
 elsif os_family == 'Debian'
   repo_host = 'apt.puppetlabs.com'
   repo_os = @host.operatingsystem.release_name
+elsif os_family == 'Windows'
+  repo_host = 'downloads.puppetlabs.com'
+  repo_os = 'windows'
 end
 
 if @host.param_true?('enable-puppetlabs-repo')
@@ -40,5 +44,10 @@ apt-get update
 apt-get -y install ca-certificates
 wget -O /tmp/<%= repo_name %>-<%= repo_os %>.deb<%= proxy_string %> https://<%= repo_host %>/<%= repo_name %>-<%= repo_os %>.deb
 dpkg -i /tmp/<%= repo_name %>-<%= repo_os %>.deb
+<% elsif os_family == 'Windows' -%>
+$puppet_agent_source = 'https://<%= repo_host %>/<%= repo_os %>/puppet-agent-<%= @host.architecture %>-latest.msi'
+$puppet_agent_msi = "${env:TEMP}\puppet-agent-<%= @host.architecture %>.msi"
+Write-Host "Downloading puppet-agent from ${$puppet_agent_source} to ${puppet_agent_msi}"
+Start-BitsTransfer -Source "${puppet_agent_source}" -Destination "${puppet_agent_msi}"<%= proxy_string_bits %>
 <% end -%>
 <% end -%>


### PR DESCRIPTION
I have expanded the puppet repo, puppet install, and puppet config snippets to support windows. The modifications are written in powershell and have been tested on windows server 2016. This allows installation of puppet-agent during the finish phase by including:
```
<%= snippet 'puppetlabs_repo' %>
<%= snippet 'puppet_setup' %>
```

- `puppet.conf.erb` add default windows paths.
- `puppet_setup.erb` add powershell scripts to install downloaded puppet-agent.msi
- `puppetlabs_repo.erb` download latest puppet-agent.msi from downloads.puppetlabs.com.