### PR TITLE
Add support for a proxy for SLES installs

### DIFF
--- a/provisioning_templates/PXELinux/autoyast_default_pxelinux.erb
+++ b/provisioning_templates/PXELinux/autoyast_default_pxelinux.erb
@@ -5,7 +5,7 @@ oses:
 - SLES
 - OpenSUSE
 %>
-<% http_proxy_string = @host.params['http-proxy'] ? "proxy=" + @host.params['http-proxy'] + ":" + @host.params['http-proxy-port'] : '' -%>
+<% http_proxy_string = @host.params['http-proxy'] ? "proxy=http://" + @host.params['http-proxy'] + ":" + @host.params['http-proxy-port'] : '' -%>
 
 DEFAULT linux
 

--- a/provisioning_templates/PXELinux/autoyast_default_pxelinux.erb
+++ b/provisioning_templates/PXELinux/autoyast_default_pxelinux.erb
@@ -5,8 +5,10 @@ oses:
 - SLES
 - OpenSUSE
 %>
+<% http_proxy_string = @host.params['http-proxy'] ? "proxy=" + @host.params['http-proxy'] + ":" + @host.params['http-proxy-port'] : '' -%>
+
 DEFAULT linux
 
 LABEL linux
     KERNEL <%= @kernel %>
-    APPEND initrd=<%= @initrd %> ramdisk_size=65536 install=<%= @mediapath %> autoyast=<%= foreman_url('provision') %> textmode=1
+    APPEND initrd=<%= @initrd %> ramdisk_size=65536 install=<%= @mediapath %> autoyast=<%= foreman_url('provision') %> textmode=1 <%= http_proxy_string -%>


### PR DESCRIPTION
This simple patch enables using a proxy during SLES autoyast installs. This is the second version of this pull request, which uses a ternary expression as requested by @mmoll .


