### PR TITLE
fix authorized_keys in create_users snippet

### DIFF
--- a/provisioning_templates/snippet/create_users.erb
+++ b/provisioning_templates/snippet/create_users.erb
@@ -12,9 +12,9 @@ snippet: true
 <%-     index = 0 -%>
 <%-     user.ssh_keys.each do |key| -%>
 <%-       if index == 0 -%>
-<%=        "#{key.type} #{key.key} #{key.comment}" %>
+<%=        "#{key.type} #{key.ssh_key} #{key.comment}" %>
 <%-       else -%>
-<%=        "#{key.type} #{key.key} #{key.comment} - #{index}" %>
+<%=        "#{key.type} #{key.ssh_key} #{key.comment} - #{index}" %>
 <%-       end -%>
 <%-       index += 1 -%>
 <%-     end -%>


### PR DESCRIPTION
use .ssh_key instead of .key, as we already use .type
and .key contains both .type and .ssh_key