### PR TITLE
Primary is not provision

### DIFF
--- a/provisioning_templates/provision/preseed_default.erb
+++ b/provisioning_templates/provision/preseed_default.erb
@@ -21,7 +21,7 @@ d-i keyboard-configuration/xkb-keymap seen true
 d-i console-keymaps-at/keymap seen true
 <% end -%>
 
-<% subnet = @host.subnet -%>
+<% subnet = @host.provision_interface -%>
 <% if subnet.respond_to?(:dhcp_boot_mode?) -%>
   <% dhcp = subnet.dhcp_boot_mode? && !@static -%>
 <% else -%>


### PR DESCRIPTION
Without this patch the Debian installer will try to install from the primary interface, which in my case not configured for such purposes.

I have a caching proxy mirror setup which hosts all packages, it also is the management access for foreman, puppet, monitoring, etc.

I do not want my hosts to access the internet to get packages and updates, this would cause a massive bandwidth overhead.