### PR TITLE
Fix the TYPE's of ifcfgs

### DIFF
--- a/provisioning_templates/snippet/kickstart_ifcfg_bond_interface.erb
+++ b/provisioning_templates/snippet/kickstart_ifcfg_bond_interface.erb
@@ -9,7 +9,7 @@ kind: snippet
                   :subnet => @subnet,
                   :subnet6 => @subnet6,
                   :dhcp => @dhcp }) -%>
-TYPE=Bond
+TYPE=bonding
 BONDING_OPTS="<%= @interface.bond_options -%> mode=<%= @interface.mode -%>"
 BONDING_MASTER=yes
 NM_CONTROLLED=no

--- a/provisioning_templates/snippet/kickstart_ifcfg_generic_interface.erb
+++ b/provisioning_templates/snippet/kickstart_ifcfg_generic_interface.erb
@@ -48,10 +48,10 @@ DEFROUTE=<%= primary %>
 <%-   if @interface.identifier.match(/^vlan\d+/) -%>
 <%=     "VLAN_NAME_TYPE=VLAN_PLUS_VID_NO_PAD" %>
 <%=     "PHYSDEV=#{@interface.attached_to}" %>
-<%-     if bonding_interfaces.include?(interface.attached_to) -%>
-<%=       "TYPE=bonding" %>
-<%-     end -%>
+<%-   end -%>
+<%-   if bonding_interfaces.include?(interface.attached_to) -%>
+<%=     "TYPE=bonding" %>
 <%-   end -%>
 <%- elsif @interface.virtual? && !@subnet.nil? && !@subnet.has_vlanid? && @interface.identifier.include?(':') -%>
-<%=   "TYPE=Alias" %>
+<%=   "TYPE=alias" %>
 <%- end -%>


### PR DESCRIPTION
The network setup tools (at least for RHEL and CentOS) check the TYPE of
interfaces in some cases; they test for `bonding`, not `bond` or `Bond`.

Also, a vlan on top of a bond should also have this `TYPE=bonding`; the
vlan can not be activated if the `TYPE` is not set. The error I got in
this case was:

```
Error: Connection activation failed: Connection 'Vlan vlan123' is not
available on the device vlan123 at this time.
```

(Interface `vlan123` was configured on top of interface `bond0`, on top
of interfaces `eth0` and `eth1`).

This error was resolved as soon as I added `TYPE=bonding` to
`ifcfg-vlan123` - adding `TYPE=Bond` dit *NOT* work.

I have no idea whether the `TYPE=Alias` is used for anything, I could
not find it but would assume consistency from the side of the
developers...