### PR TITLE
An interface may only have an ipv6 subnet attached

### DIFF
--- a/provisioning_templates/snippet/kickstart_networking_setup.erb
+++ b/provisioning_templates/snippet/kickstart_networking_setup.erb
@@ -31,7 +31,7 @@ kind: snippet
 <%- end -%>
 
 <%- @host.managed_interfaces.each do |interface| %>
-<%-   next if !interface.managed? || interface.subnet.nil? -%>
+<%-   next if !interface.managed? || (interface.subnet.nil? && interface.subnet6.nil?) -%>
 <%-   next if bonded_interfaces.include?(interface.identifier) -%>
 
 <%=   "# #{interface.identifier} interface" %>


### PR DESCRIPTION
This will still generate the network interface if only an ipv6 subnet is
attached to a given (regular) interface.