### PR TITLE
Remove SSH key type from create_users

### DIFF
--- a/provisioning_templates/snippet/create_users.erb
+++ b/provisioning_templates/snippet/create_users.erb
@@ -12,9 +12,9 @@ snippet: true
 <%-     index = 0 -%>
 <%-     user.ssh_keys.each do |key| -%>
 <%-       if index == 0 -%>
-<%=        "#{key.type} #{key.ssh_key} #{key.comment}" %>
+<%=        "#{key.ssh_key} #{key.comment}" %>
 <%-       else -%>
-<%=        "#{key.type} #{key.ssh_key} #{key.comment} - #{index}" %>
+<%=        "#{key.ssh_key} #{key.comment} - #{index}" %>
 <%-       end -%>
 <%-       index += 1 -%>
 <%-     end -%>


### PR DESCRIPTION
In Foreman, you cannot write the SSH key without the key type.
This content is already in `ssh_key`, so there is no need to put it
twice using `key.type`. In fact this would not work in .authorized_keys

![screenshot from 2017-06-14 14-13-23](https://user-images.githubusercontent.com/598891/27131674-fed3d724-510b-11e7-9964-eeca9aa841c9.png)
