### PR TITLE
Trigger kickstart networking provisioning with only IPv6

### DIFF
--- a/provisioning_templates/provision/kickstart_default.erb
+++ b/provisioning_templates/provision/kickstart_default.erb
@@ -137,7 +137,7 @@ exec < /dev/tty3 > /dev/tty3
 #changing to VT 3 so that we can see whats going on....
 /usr/bin/chvt 3
 (
-<% if subnet.respond_to?(:dhcp_boot_mode?) -%>
+<% if subnet.respond_to?(:dhcp_boot_mode?) || @host.subnet6.respond_to?(:dhcp_boot_mode?) -%>
 <%= snippet 'kickstart_networking_setup' %>
 <% end -%>
 

--- a/provisioning_templates/provision/kickstart_rhel_default.erb
+++ b/provisioning_templates/provision/kickstart_rhel_default.erb
@@ -114,7 +114,7 @@ exec < /dev/tty3 > /dev/tty3
 #changing to VT 3 so that we can see whats going on....
 /usr/bin/chvt 3
 (
-<% if subnet.respond_to?(:dhcp_boot_mode?) -%>
+<% if subnet.respond_to?(:dhcp_boot_mode?) || @host.subnet6.respond_to?(:dhcp_boot_mode?) -%>
 <%= snippet 'kickstart_networking_setup' %>
 <% end -%>
 


### PR DESCRIPTION
If a host has managed IPv6 networks, but no IPv4, the kickstart will
not even try to configure it. This change allows to configure if:

Only IPv4 is present
Only IPv6 is present
Both IPv4 and IPv6 are present

cc @jovandeginste might be useful for you, I needed the changes you made to the kickstart networking snippet for this to make any sense.