### PR TITLE
Ansible Tower provisoning callback

### DIFF
--- a/provisioning_templates/provision/kickstart_default.erb
+++ b/provisioning_templates/provision/kickstart_default.erb
@@ -192,6 +192,15 @@ yum -t -y remove kernel-uek*
 sed -e 's/DEFAULTKERNEL=kernel-uek/DEFAULTKERNEL=kernel/g' -i /etc/sysconfig/kernel
 <% end -%>
 
+# This is RHEL7 specific code, as it uses systemctl, replace with
+# chkconfig or an @boot cron if you run RHEL5 or RHEL6
+<% if realm_compatible && host_param_true?('ansible_tower_provisioning') %>
+<%= save_to_file('/etc/systemd/system/ansible-callback.service',
+                 snippet('ansible_tower_callback_service')) %>
+# Runs during first boot, removes itself
+/usr/bin/systemctl enable ansible-callback
+<% end -%>
+
 sync
 
 # Inform the build system that we are done.

--- a/provisioning_templates/provision/kickstart_rhel_default.erb
+++ b/provisioning_templates/provision/kickstart_rhel_default.erb
@@ -165,6 +165,15 @@ fi
 <%= snippet 'saltstack_setup' %>
 <% end -%>
 
+# This is RHEL7 specific code, as it uses systemctl, replace with
+# chkconfig or an @boot cron if you run RHEL5 or RHEL6
+<% if realm_compatible && host_param_true?('ansible_tower_provisioning') %>
+<%= save_to_file('/etc/systemd/system/ansible-callback.service',
+                 snippet('ansible_tower_callback_service')) %>
+# Runs during first boot, removes itself
+/usr/bin/systemctl enable ansible-callback
+<% end -%>
+
 sync
 
 # Inform the build system that we are done.

--- a/provisioning_templates/snippet/ansible_tower_callback_service.erb
+++ b/provisioning_templates/snippet/ansible_tower_callback_service.erb
@@ -1,0 +1,16 @@
+<%#
+kind: snippet
+name: ansible_tower_callback_service
+-%>
+[Unit]
+Description=Provisioning callback to Ansible Tower
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/curl -k -s --data "host_config_key=<%= host_param('ansible_host_config_key') -%>" https://<%= host_param('ansible_tower_fqdn') -%>/api/v1/job_templates/<%= host_param('ansible_job_template_id') -%>/callback/
+ExecStartPost=/usr/bin/systemctl disable ansible-callback
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Service to pull and run provisioning scripts from Ansible tower
post-installation. The snippet is compatible only with systemd-enabled
servers for the moment

props & shoutouts to @wzzrd