### PR TITLE
Complement to Bug #20814

### DIFF
--- a/provisioning_templates/snippet/pxegrub2_discovery.erb
+++ b/provisioning_templates/snippet/pxegrub2_discovery.erb
@@ -7,7 +7,9 @@ discovery image is based on CentOS/RHEL and therefor it is affected by https://b
 In short, before RHEL 7.2 virtio driver didn't have the new persistent naming scheme, causing interfaces to be named eth0, eth1, etc..
 If you want to enable the new persistent naming scheme and get inteface names like ens3, add net.ifnames=1 to the linuxefi line below.
 -%>
+mac=${m1}:${m2}:${m3}:${m4}:${m5}:${m6}
+
 menuentry 'Foreman Discovery Image' {
-  linuxefi boot/fdi-image/vmlinuz0 rootflags=loop root=live:/fdi.iso rootfstype=auto ro rd.live.image acpi=force rd.luks=0 rd.md=0 rd.dm=0 rd.lvm=0 rd.bootif=0 rd.neednet=0 nomodeset proxy.url=<%= foreman_server_url %> proxy.type=foreman BOOTIF=01-$net_default_mac
+  linuxefi boot/fdi-image/vmlinuz0 rootflags=loop root=live:/fdi.iso rootfstype=auto ro rd.live.image acpi=force rd.luks=0 rd.md=0 rd.dm=0 rd.lvm=0 rd.bootif=0 rd.neednet=0 nomodeset proxy.url=<%= foreman_server_url %> proxy.type=foreman BOOTIF=01-$mac
   initrdefi boot/fdi-image/initrd0.img
 }


### PR DESCRIPTION
Because of the buggy GRUB2 in RHEL/CentOS 7.4, we also need to remove the last ':' from the MAC address for Foreman Discovery cmdline.