### PR TITLE
Fix BOOTIF MAC address notation in preseed_default_ipxe

### DIFF
--- a/provisioning_templates/iPXE/preseed_default_ipxe.erb
+++ b/provisioning_templates/iPXE/preseed_default_ipxe.erb
@@ -16,7 +16,7 @@ oses:
 <% initrd = boot_files_uris[1] -%>
 <% static = @host.token.nil? ? '?static=yes' : '&static=yes' -%>
 
-kernel <%= kernel %> interface=auto url=<%= foreman_url('provision')%><%= static %> ramdisk_size=10800 root=/dev/rd/0 rw auto netcfg/disable_dhcp=true BOOTIF=${netX/mac} hostname=<%= @host.name %> <%= keyboard_params %> locale=<%= host_param('lang') || 'en_US' %> netcfg/get_ipaddress=${netX/ip} netcfg/get_netmask=${netX/netmask} netcfg/get_gateway=${netX/gateway} netcfg/get_nameservers=${dns} netcfg/confirm_static=true
+kernel <%= kernel %> interface=auto url=<%= foreman_url('provision')%><%= static %> ramdisk_size=10800 root=/dev/rd/0 rw auto netcfg/disable_dhcp=true BOOTIF=01-${netX/mac:hexhyp} hostname=<%= @host.name %> <%= keyboard_params %> locale=<%= host_param('lang') || 'en_US' %> netcfg/get_ipaddress=${netX/ip} netcfg/get_netmask=${netX/netmask} netcfg/get_gateway=${netX/gateway} netcfg/get_nameservers=${dns} netcfg/confirm_static=true
 initrd <%= initrd %>
 
 boot


### PR DESCRIPTION
This patch fixes MAC address notation convention of BOOTIF parameter.
Debian-installer doesn't recognize BOOTIF parameter with colon separated values.
The following is an message recorded in /var/log/installer/syslog.

```
netcfg[2157]: INFO: Could not find valid BOOTIF= entry in /proc/cmdline
```

If the secondary NIC (e.g. eno2) is a provisioning network, installation fails at the time of network detection.
This patch changes the notation to 01 prefix hyphen separated values.
