### PR TITLE
Updates to AWX provisioning callback

### DIFF
--- a/provisioning_templates/finish/kickstart_default_finish.erb
+++ b/provisioning_templates/finish/kickstart_default_finish.erb
@@ -77,6 +77,11 @@ fi
 <%= snippet 'saltstack_setup' %>
 <% end -%>
 
+<% if host_param_true?('ansible_tower_provisioning') -%>
+<%= save_to_file('/root/ansible_provisioning_call.sh', snippet('ansible_tower_callback_script')) %>
+./root/ansible_provisioning_call.sh
+<% end -%>
+
 sync
 
 exit 0

--- a/provisioning_templates/provision/kickstart_default.erb
+++ b/provisioning_templates/provision/kickstart_default.erb
@@ -192,14 +192,7 @@ yum -t -y remove kernel-uek*
 sed -e 's/DEFAULTKERNEL=kernel-uek/DEFAULTKERNEL=kernel/g' -i /etc/sysconfig/kernel
 <% end -%>
 
-<% if realm_compatible && host_param_true?('ansible_tower_provisioning') %>
-# This is RHEL7 specific code, as it uses systemctl, replace with
-# chkconfig or an @boot cron if you run RHEL5 or RHEL6
-<%= save_to_file('/etc/systemd/system/ansible-callback.service',
-                 snippet('ansible_tower_callback_service')) %>
-# Runs during first boot, removes itself
-/usr/bin/systemctl enable ansible-callback
-<% end -%>
+<%= snippet('ansible_provisioning_callback') %>
 
 sync
 

--- a/provisioning_templates/provision/kickstart_rhel_default.erb
+++ b/provisioning_templates/provision/kickstart_rhel_default.erb
@@ -165,14 +165,8 @@ fi
 <%= snippet 'saltstack_setup' %>
 <% end -%>
 
-<% if realm_compatible && host_param_true?('ansible_tower_provisioning') %>
-# This is RHEL7 specific code, as it uses systemctl, replace with
-# chkconfig or an @boot cron if you run RHEL5 or RHEL6
-<%= save_to_file('/etc/systemd/system/ansible-callback.service',
-                 snippet('ansible_tower_callback_service')) %>
-# Runs during first boot, removes itself
-/usr/bin/systemctl enable ansible-callback
-<% end -%>
+<%= snippet('ansible_provisioning_callback') %>
+
 
 sync
 

--- a/provisioning_templates/snippet/ansible_provisioning_callback.erb
+++ b/provisioning_templates/snippet/ansible_provisioning_callback.erb
@@ -1,0 +1,21 @@
+<%#
+kind: snippet
+name: ansible_provisioning_callback
+-%>
+<% if host_param_true?('ansible_tower_provisioning') -%>
+<%
+  rhel_compatible = @host.operatingsystem.family == 'Redhat' && @host.operatingsystem.name != 'Fedora'
+  os_major = @host.operatingsystem.major.to_i
+  has_systemd = (@host.operatingsystem.name == 'Fedora' && os_major >= 20) || (rhel_compatible && os_major >= 7)
+-%>
+<% if has_systemd -%>
+<%= save_to_file('/etc/systemd/system/ansible-callback.service',
+                 snippet('ansible_tower_callback_service')) %>
+# Runs during first boot, removes itself
+systemctl enable ansible-callback
+<% else -%>
+# Assume systemd is not available
+<%= save_to_file('/root/ansible_provisioning_call.sh', snippet('ansible_tower_callback_script')) %>
+(crontab -u root -l 2>/dev/null; echo "@reboot /root/ansible_provisioning_call.sh" ) | crontab -u root -
+<% end -%>
+<% end -%>

--- a/provisioning_templates/snippet/ansible_tower_callback_script.erb
+++ b/provisioning_templates/snippet/ansible_tower_callback_script.erb
@@ -1,0 +1,9 @@
+<%#
+kind: snippet
+name: ansible_tower_callback_script
+-%>
+#!/bin/sh
+
+echo "Calling Ansible AWX/Tower provisioning callback..."
+/usr/bin/curl -v -k -s --data "host_config_key=<%= host_param('ansible_host_config_key') %>" https://<%= host_param('ansible_tower_fqdn') %>/api/v2/job_templates/<%= host_param('ansible_job_template_id') %>/callback/
+echo "DONE"

--- a/provisioning_templates/snippet/ansible_tower_callback_service.erb
+++ b/provisioning_templates/snippet/ansible_tower_callback_service.erb
@@ -9,7 +9,7 @@ After=network-online.target
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/curl -k -s --data "host_config_key=<%= host_param('ansible_host_config_key') -%>" https://<%= host_param('ansible_tower_fqdn') -%>/api/v1/job_templates/<%= host_param('ansible_job_template_id') -%>/callback/
+ExecStart=/usr/bin/curl -k -s --data "host_config_key=<%= host_param('ansible_host_config_key') -%>" https://<%= host_param('ansible_tower_fqdn') -%>/api/v2/job_templates/<%= host_param('ansible_job_template_id') -%>/callback/
 ExecStartPost=/usr/bin/systemctl disable ansible-callback
 
 [Install]


### PR DESCRIPTION
This modifies the templates so that the provisioning callback from Ansible Tower or AWX can happen on systems without systemd, and also during image-based provisioning.