### PR TITLE
Allow EPEL repo URL base to be changed

### DIFF
--- a/provisioning_templates/snippet/epel.erb
+++ b/provisioning_templates/snippet/epel.erb
@@ -3,8 +3,9 @@ kind: snippet
 name: epel
 -%>
 <%
+repo_base  = host_param('epel-repo-base') ? host_param('epel-repo-base') : 'https://dl.fedoraproject.org/pub/epel'
 http_proxy = host_param('http-proxy') ? " --httpproxy #{host_param('http-proxy')}" : nil
 http_port  = host_param('http-proxy-port') ? " --httpport #{host_param('http-proxy-port')}" : nil
 os_major   = @host.operatingsystem.major.to_i
 -%>
-rpm -Uvh<%= http_proxy %><%= http_port %> https://dl.fedoraproject.org/pub/epel/epel-release-latest-<%= os_major %>.noarch.rpm
+rpm -Uvh<%= http_proxy %><%= http_port %> <%= repo_base %>/epel-release-latest-<%= os_major %>.noarch.rpm


### PR DESCRIPTION
This would be handy for sites that prefer to use a local mirror.