### PR TITLE
fixes #21694 - Add MTU support for kickstart installations

### DIFF
--- a/provisioning_templates/provision/atomic_kickstart_default.erb
+++ b/provisioning_templates/provision/atomic_kickstart_default.erb
@@ -15,7 +15,7 @@ timezone --utc <%= host_param('time-zone') || 'UTC' %>
 <% dhcp = !@static -%>
 <% end -%>
 
-network --bootproto <%= dhcp ? 'dhcp' : "static --ip=#{@host.ip} --netmask=#{subnet.mask} --gateway=#{subnet.gateway} --nameserver=#{[subnet.dns_primary, subnet.dns_secondary].select{ |item| item.present? }.join(',')}" %> --hostname <%= @host %><%= " --device=#{@host.mac}" -%>
+network --bootproto <%= dhcp ? 'dhcp' : "static --ip=#{@host.ip} --netmask=#{subnet.mask} --gateway=#{subnet.gateway} --nameserver=#{[subnet.dns_primary, subnet.dns_secondary].select{ |item| item.present? }.join(',')} --mtu=#{subnet.mtu.to_s}" %> --hostname <%= @host %><%= " --device=#{@host.mac}" -%>
 
 # Partition table should create /boot and a volume atomicos
 <% if @dynamic -%>

--- a/provisioning_templates/provision/kickstart_default.erb
+++ b/provisioning_templates/provision/kickstart_default.erb
@@ -52,7 +52,8 @@ skipx
 <% else -%>
 <% dhcp = !@static -%>
 <% end -%>
-network --bootproto <%= dhcp ? 'dhcp' : "static --ip=#{@host.ip} --netmask=#{subnet.mask} --gateway=#{subnet.gateway} --nameserver=#{[subnet.dns_primary, subnet.dns_secondary].select{ |item| item.present? }.join(',')}" %> --hostname <%= @host %><%= os_major >= 6 ? " --device=#{@host.mac}" : '' -%>
+
+network --bootproto <%= dhcp ? 'dhcp' : "static --ip=#{@host.ip} --netmask=#{subnet.mask} --gateway=#{subnet.gateway} --nameserver=#{[subnet.dns_primary, subnet.dns_secondary].select{ |item| item.present? }.join(',')} --mtu=#{subnet.mtu.to_s}" %> --hostname <%= @host %><%= os_major >= 6 ? " --device=#{@host.mac}" : '' -%>
 
 rootpw --iscrypted <%= root_pass %>
 <% if host_param_true?('disable-firewall') -%>

--- a/provisioning_templates/snippet/kickstart_ifcfg_generic_interface.erb
+++ b/provisioning_templates/snippet/kickstart_ifcfg_generic_interface.erb
@@ -56,3 +56,8 @@ DEFROUTE=<%= primary %>
 <%- elsif @interface.virtual? && !@subnet.nil? && !@subnet.has_vlanid? && @interface.identifier.include?(':') -%>
 <%=   "TYPE=Alias" %>
 <%- end -%>
+<%- if @subnet -%>
+<%=   "MTU=#{@subnet.mtu}" %>
+<%- elsif @subnet6 -%>
+<%=   "MTU=#{@subnet6.mtu}" %>
+<%- end -%>

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -87,13 +87,15 @@ class FakeNamespace
       ),
       :as_string => name,
       :subnet => FakeStruct.new(
-        :dhcp_boot_mode? => true
+        :dhcp_boot_mode? => true,
+        :mtu => 1500
       ),
       :mac => '00:00:00:00:00:01',
       :primary_interface => FakeStruct.new(
         :identifier => 'eth0',
         :subnet => FakeStruct.new(
-          :dhcp_boot_mode? => true
+          :dhcp_boot_mode? => true,
+        :mtu => 9000
         ),
       ),
      :managed_interfaces => [
@@ -103,7 +105,8 @@ class FakeNamespace
          :primary => true,
          :ip => '1.2.3.4',
          :subnet => FakeStruct.new(
-           :dhcp_boot_mode? => true
+           :dhcp_boot_mode? => true,
+           :mtu => 1496
          ),
        ),
      ]


### PR DESCRIPTION
Template parts for [#21694](http://projects.theforeman.org/issues/21694).

Adding MTU support for kickstart templates. I didn't see any resources about MTU support at provisioning time on other distribution (except for Suse)