### PR TITLE
Add model metadata attribute

### DIFF
--- a/job_templates/package_action_-_ssh_default.erb
+++ b/job_templates/package_action_-_ssh_default.erb
@@ -1,6 +1,7 @@
 <%#
 kind: job_template
 name: Package Action - SSH Default
+model: JobTemplate
 job_category: Packages
 description_format: "%{action} package(s) %{package}"
 provider_type: SSH

--- a/job_templates/power_action_-_ssh_default.erb
+++ b/job_templates/power_action_-_ssh_default.erb
@@ -1,6 +1,7 @@
 <%#
 kind: job_template
 name: Power Action - SSH Default
+model: JobTemplate
 job_category: Power
 description_format: '%{action} host'
 provider_type: SSH

--- a/job_templates/puppet_run_once_-_ssh_default.erb
+++ b/job_templates/puppet_run_once_-_ssh_default.erb
@@ -1,6 +1,7 @@
 <%#
 kind: job_template
 name: Puppet Run Once - SSH Default
+model: JobTemplate
 job_category: Puppet
 description_format: 'Run Puppet once with "%{puppet_options}"'
 provider_type: SSH

--- a/job_templates/run_command_-_ssh_default.erb
+++ b/job_templates/run_command_-_ssh_default.erb
@@ -1,6 +1,7 @@
 <%#
 kind: job_template
 name: Run Command - SSH Default
+model: JobTemplate
 job_category: Commands
 description_format: "Run %{command}"
 provider_type: SSH

--- a/job_templates/service_action_-_ssh_default.erb
+++ b/job_templates/service_action_-_ssh_default.erb
@@ -1,6 +1,7 @@
 <%#
 kind: job_template
 name: Service Action - SSH Default
+model: JobTemplate
 job_category: Services
 description_format: '%{action} service %{service}'
 provider_type: SSH

--- a/job_templates/start_openscap_scans.erb
+++ b/job_templates/start_openscap_scans.erb
@@ -1,5 +1,6 @@
 <%#
 name: Start OpenSCAP scans
+model: JobTemplate
 job_category: OpenSCAP
 description_format: Check all OpenSCAP policices, you must have OpenSCAP plugin setup in order for this template to work
 snippet: false

--- a/partition_tables_templates/autoyast_entire_scsi_disk.erb
+++ b/partition_tables_templates/autoyast_entire_scsi_disk.erb
@@ -1,6 +1,7 @@
 <%#
 kind: ptable
 name: AutoYaST entire SCSI disk
+model: Ptable
 oses:
 - SLES
 - OpenSUSE

--- a/partition_tables_templates/autoyast_entire_virtual_disk.erb
+++ b/partition_tables_templates/autoyast_entire_virtual_disk.erb
@@ -1,6 +1,7 @@
 <%#
 kind: ptable
 name: AutoYaST entire virtual disk
+model: Ptable
 oses:
 - SLES
 - OpenSUSE

--- a/partition_tables_templates/autoyast_lvm.erb
+++ b/partition_tables_templates/autoyast_lvm.erb
@@ -1,6 +1,7 @@
 <%#
 kind: ptable
 name: AutoYaST LVM
+model: Ptable
 oses:
 - SLES
 - OpenSUSE

--- a/partition_tables_templates/coreos_default_fake.erb
+++ b/partition_tables_templates/coreos_default_fake.erb
@@ -1,6 +1,7 @@
 <%#
 kind: ptable
 name: CoreOS default fake
+model: Ptable
 oses:
 - CoreOS
 %>

--- a/partition_tables_templates/freebsd_default_fake.erb
+++ b/partition_tables_templates/freebsd_default_fake.erb
@@ -1,6 +1,7 @@
 <%#
 kind: ptable
 name: FreeBSD default fake
+model: Ptable
 oses:
 - FreeBSD
 %>

--- a/partition_tables_templates/jumpstart_default.erb
+++ b/partition_tables_templates/jumpstart_default.erb
@@ -1,6 +1,7 @@
 <%#
 kind: ptable
 name: Jumpstart default
+model: Ptable
 %>
 filesys c0t0d0s0 7000 /
 filesys c0t0d0s1 1000 swap

--- a/partition_tables_templates/jumpstart_mirrored.erb
+++ b/partition_tables_templates/jumpstart_mirrored.erb
@@ -1,6 +1,7 @@
 <%#
 kind: ptable
 name: Jumpstart mirrored
+model: Ptable
 %>
 filesys mirror:d10 c1t0d0s0 c1t1d0s0 16000 /
 filesys mirror:d20 c1t0d0s1 c1t1d0s1 8000 swap

--- a/partition_tables_templates/junos_default_fake.erb
+++ b/partition_tables_templates/junos_default_fake.erb
@@ -1,5 +1,6 @@
 <%#
 kind: ptable
 name: Junos default fake
+model: Ptable
 %>
 # Not required for Junos ZTP provisioning.

--- a/partition_tables_templates/kickstart_default.erb
+++ b/partition_tables_templates/kickstart_default.erb
@@ -1,6 +1,7 @@
 <%#
 kind: ptable
 name: Kickstart default
+model: Ptable
 oses:
 - CentOS
 - Fedora

--- a/partition_tables_templates/nx-os_default_fake.erb
+++ b/partition_tables_templates/nx-os_default_fake.erb
@@ -1,6 +1,7 @@
 <%#
 kind: ptable
 name: NX-OS default fake
+model: Ptable
 oses:
 - NX-OS
 %>

--- a/partition_tables_templates/preseed_default.erb
+++ b/partition_tables_templates/preseed_default.erb
@@ -1,6 +1,7 @@
 <%#
 kind: ptable
 name: Preseed default
+model: Ptable
 oses:
 - Debian
 - Ubuntu

--- a/partition_tables_templates/preseed_default_lvm.erb
+++ b/partition_tables_templates/preseed_default_lvm.erb
@@ -1,6 +1,7 @@
 <%#
 kind: ptable
 name: Preseed default LVM
+model: Ptable
 oses:
 - Debian
 - Ubuntu

--- a/partition_tables_templates/xenserver_default.erb
+++ b/partition_tables_templates/xenserver_default.erb
@@ -1,6 +1,7 @@
 <%#
 kind: ptable
 name: XenServer default
+model: Ptable
 oses:
 - XenServer
 -%>

--- a/provisioning_templates/POAP/nx-os_default_poap_setup.erb
+++ b/provisioning_templates/POAP/nx-os_default_poap_setup.erb
@@ -1,6 +1,7 @@
 <%#
 kind: POAP
 name: NX-OS default POAP setup
+model: ProvisioningTemplate
 oses:
 - NX-OS
 %>

--- a/provisioning_templates/PXEGrub/jumpstart_default_pxegrub.erb
+++ b/provisioning_templates/PXEGrub/jumpstart_default_pxegrub.erb
@@ -1,6 +1,7 @@
 <%#
 kind: PXEGrub
 name: Jumpstart default PXEGrub
+model: ProvisioningTemplate
 %>
 default=0
 timeout=10

--- a/provisioning_templates/PXEGrub/kickstart_default_pxegrub.erb
+++ b/provisioning_templates/PXEGrub/kickstart_default_pxegrub.erb
@@ -1,6 +1,7 @@
 <%#
 kind: PXEGrub
 name: Kickstart default PXEGrub
+model: ProvisioningTemplate
 oses:
 - CentOS
 - Fedora

--- a/provisioning_templates/PXEGrub/pxegrub_default_local_boot.erb
+++ b/provisioning_templates/PXEGrub/pxegrub_default_local_boot.erb
@@ -1,6 +1,7 @@
 <%#
 kind: PXEGrub
 name: PXEGrub default local boot
+model: ProvisioningTemplate
 %>
 <%# Used to boot provisioned hosts, do not associate or change the name. %>
 

--- a/provisioning_templates/PXEGrub/pxegrub_global_default.erb
+++ b/provisioning_templates/PXEGrub/pxegrub_global_default.erb
@@ -1,6 +1,7 @@
 <%#
 kind: PXEGrub
 name: PXEGrub global default
+model: ProvisioningTemplate
 %>
 <%# Used to boot unknown hosts, do not associate or change the name. %>
 

--- a/provisioning_templates/PXEGrub2/kickstart_default_pxegrub2.erb
+++ b/provisioning_templates/PXEGrub2/kickstart_default_pxegrub2.erb
@@ -1,6 +1,7 @@
 <%#
 kind: PXEGrub2
 name: Kickstart default PXEGrub2
+model: ProvisioningTemplate
 oses:
 - CentOS
 - Fedora

--- a/provisioning_templates/PXEGrub2/preseed_default_pxegrub2.erb
+++ b/provisioning_templates/PXEGrub2/preseed_default_pxegrub2.erb
@@ -1,6 +1,7 @@
 <%#
 kind: PXEGrub2
 name: Preseed default PXEGrub2
+model: ProvisioningTemplate
 oses:
 - Debian
 - Ubuntu

--- a/provisioning_templates/PXEGrub2/pxegrub2_default_local_boot.erb
+++ b/provisioning_templates/PXEGrub2/pxegrub2_default_local_boot.erb
@@ -1,6 +1,7 @@
 <%#
 kind: PXEGrub2
 name: PXEGrub2 default local boot
+model: ProvisioningTemplate
 %>
 <%# Used to boot provisioned hosts, do not associate or change the name. %>
 

--- a/provisioning_templates/PXEGrub2/pxegrub2_global_default.erb
+++ b/provisioning_templates/PXEGrub2/pxegrub2_global_default.erb
@@ -1,6 +1,7 @@
 <%#
 kind: PXEGrub2
 name: PXEGrub2 global default
+model: ProvisioningTemplate
 %>
 <%# Used to boot unknown hosts, do not associate or change the name. %>
 

--- a/provisioning_templates/PXELinux/alterator_default_pxelinux.erb
+++ b/provisioning_templates/PXELinux/alterator_default_pxelinux.erb
@@ -1,6 +1,7 @@
 <%#
 kind: PXELinux
 name: Alterator default PXELinux
+model: ProvisioningTemplate
 oses:
 - ALTLinux p6
 - ALTLinux p7

--- a/provisioning_templates/PXELinux/autoyast_default_pxelinux.erb
+++ b/provisioning_templates/PXELinux/autoyast_default_pxelinux.erb
@@ -1,6 +1,7 @@
 <%#
 kind: PXELinux
 name: AutoYaST default PXELinux
+model: ProvisioningTemplate
 oses:
 - SLES
 - OpenSUSE

--- a/provisioning_templates/PXELinux/coreos_pxelinux.erb
+++ b/provisioning_templates/PXELinux/coreos_pxelinux.erb
@@ -1,6 +1,7 @@
 <%#
 kind: PXELinux
 name: CoreOS PXELinux
+model: ProvisioningTemplate
 oses:
 - CoreOS
 %>

--- a/provisioning_templates/PXELinux/freebsd_(mfsbsd)_pxelinux.erb
+++ b/provisioning_templates/PXELinux/freebsd_(mfsbsd)_pxelinux.erb
@@ -1,6 +1,7 @@
 <%#
 kind: PXELinux
 name: FreeBSD (mfsBSD) PXELinux
+model: ProvisioningTemplate
 oses:
 - FreeBSD
 %>

--- a/provisioning_templates/PXELinux/kickstart_default_pxelinux.erb
+++ b/provisioning_templates/PXELinux/kickstart_default_pxelinux.erb
@@ -1,6 +1,7 @@
 <%#
 kind: PXELinux
 name: Kickstart default PXELinux
+model: ProvisioningTemplate
 oses:
 - CentOS
 - Fedora

--- a/provisioning_templates/PXELinux/preseed_default_pxelinux.erb
+++ b/provisioning_templates/PXELinux/preseed_default_pxelinux.erb
@@ -1,6 +1,7 @@
 <%#
 kind: PXELinux
 name: Preseed default PXELinux
+model: ProvisioningTemplate
 oses:
 - Debian
 - Ubuntu

--- a/provisioning_templates/PXELinux/pxelinux_chain_ipxe.erb
+++ b/provisioning_templates/PXELinux/pxelinux_chain_ipxe.erb
@@ -1,6 +1,7 @@
 <%#
 kind: PXELinux
 name: PXELinux chain iPXE
+model: ProvisioningTemplate
 %>
 <%#
 Chainboots iPXE/gPXE from PXELinux. Make sure the OS has iPXE template

--- a/provisioning_templates/PXELinux/pxelinux_chain_ipxe_undi.erb
+++ b/provisioning_templates/PXELinux/pxelinux_chain_ipxe_undi.erb
@@ -1,6 +1,7 @@
 <%#
 kind: PXELinux
 name: PXELinux chain iPXE UNDI
+model: ProvisioningTemplate
 %>
 <%#
 Chainboots iPXE/gPXE from PXELinux via UNDI. Make sure the OS has an iPXE

--- a/provisioning_templates/PXELinux/pxelinux_default_local_boot.erb
+++ b/provisioning_templates/PXELinux/pxelinux_default_local_boot.erb
@@ -1,6 +1,7 @@
 <%#
 kind: PXELinux
 name: PXELinux default local boot
+model: ProvisioningTemplate
 %>
 <%# Used to boot provisioned hosts, do not associate or change the name. %>
 

--- a/provisioning_templates/PXELinux/pxelinux_default_memdisk.erb
+++ b/provisioning_templates/PXELinux/pxelinux_default_memdisk.erb
@@ -1,6 +1,7 @@
 <%#
 kind: PXELinux
 name: PXELinux default memdisk
+model: ProvisioningTemplate
 oses:
 - FreeBSD (memdisk image)
 %>

--- a/provisioning_templates/PXELinux/pxelinux_global_default.erb
+++ b/provisioning_templates/PXELinux/pxelinux_global_default.erb
@@ -1,6 +1,7 @@
 <%#
 kind: PXELinux
 name: PXELinux global default
+model: ProvisioningTemplate
 %>
 <%# Used to boot unknown hosts, do not associate or change the name. %>
 

--- a/provisioning_templates/PXELinux/waik_default_pxelinux.erb
+++ b/provisioning_templates/PXELinux/waik_default_pxelinux.erb
@@ -1,6 +1,7 @@
 <%#
 kind: PXELinux
 name: WAIK default PXELinux
+model: ProvisioningTemplate
 %>
 DEFAULT winPE
 

--- a/provisioning_templates/PXELinux/xenserver_default_pxelinux.erb
+++ b/provisioning_templates/PXELinux/xenserver_default_pxelinux.erb
@@ -1,6 +1,7 @@
 <%#
 kind: PXELinux
 name: XenServer default PXELinux
+model: ProvisioningTemplate
 oses:
 - XenServer
 %>

--- a/provisioning_templates/ZTP/junos_default_ztp_config.erb
+++ b/provisioning_templates/ZTP/junos_default_ztp_config.erb
@@ -1,6 +1,7 @@
 <%#
 kind: ZTP
 name: Junos default ZTP config
+model: ProvisioningTemplate
 -%>
 system {
     host-name <%= @host.shortname %>;

--- a/provisioning_templates/finish/alterator_default_finish.erb
+++ b/provisioning_templates/finish/alterator_default_finish.erb
@@ -1,6 +1,7 @@
 <%#
 kind: finish
 name: Alterator default finish
+model: ProvisioningTemplate
 oses:
 - ALTLinux p6
 - ALTLinux p7

--- a/provisioning_templates/finish/freebsd_(mfsbsd)_finish.erb
+++ b/provisioning_templates/finish/freebsd_(mfsbsd)_finish.erb
@@ -1,6 +1,7 @@
 <%#
 kind: finish
 name: FreeBSD (mfsBSD) finish
+model: ProvisioningTemplate
 oses:
 - FreeBSD
 %>

--- a/provisioning_templates/finish/jumpstart_default_finish.erb
+++ b/provisioning_templates/finish/jumpstart_default_finish.erb
@@ -1,6 +1,7 @@
 <%#
 kind: finish
 name: Jumpstart default finish
+model: ProvisioningTemplate
 %>
 logger "Starting finish script"
 

--- a/provisioning_templates/finish/junos_default_finish.erb
+++ b/provisioning_templates/finish/junos_default_finish.erb
@@ -1,6 +1,7 @@
 <%#
 kind: finish
 name: Junos default finish
+model: ProvisioningTemplate
 -%>
 system {
     host-name <%= @host %>;

--- a/provisioning_templates/finish/kickstart_default_finish.erb
+++ b/provisioning_templates/finish/kickstart_default_finish.erb
@@ -1,6 +1,7 @@
 <%#
 kind: finish
 name: Kickstart default finish
+model: ProvisioningTemplate
 oses:
 - CentOS
 - Fedora

--- a/provisioning_templates/finish/preseed_default_finish.erb
+++ b/provisioning_templates/finish/preseed_default_finish.erb
@@ -1,6 +1,7 @@
 <%#
 kind: finish
 name: Preseed default finish
+model: ProvisioningTemplate
 oses:
 - Debian
 - Ubuntu

--- a/provisioning_templates/finish/xenserver_default_finish.erb
+++ b/provisioning_templates/finish/xenserver_default_finish.erb
@@ -1,6 +1,7 @@
 <%#
 kind: finish
 name: XenServer default finish
+model: ProvisioningTemplate
 oses:
 - XenServer
 -%>

--- a/provisioning_templates/iPXE/autoyast_default_ipxe.erb
+++ b/provisioning_templates/iPXE/autoyast_default_ipxe.erb
@@ -2,6 +2,7 @@
 <%#
 kind: iPXE
 name: AutoYaST default iPXE
+model: ProvisioningTemplate
 oses:
 - SLES
 - OpenSUSE

--- a/provisioning_templates/iPXE/kickstart_default_ipxe.erb
+++ b/provisioning_templates/iPXE/kickstart_default_ipxe.erb
@@ -2,6 +2,7 @@
 <%#
 kind: iPXE
 name: Kickstart default iPXE
+model: ProvisioningTemplate
 oses:
 - CentOS
 - Fedora

--- a/provisioning_templates/iPXE/preseed_default_ipxe.erb
+++ b/provisioning_templates/iPXE/preseed_default_ipxe.erb
@@ -2,6 +2,7 @@
 <%#
 kind: iPXE
 name: Preseed default iPXE
+model: ProvisioningTemplate
 oses:
 - Debian
 - Ubuntu

--- a/provisioning_templates/provision/alterator_default.erb
+++ b/provisioning_templates/provision/alterator_default.erb
@@ -1,6 +1,7 @@
 <%#
 kind: provision
 name: Alterator default
+model: ProvisioningTemplate
 oses:
 - ALTLinux p6
 - ALTLinux p7

--- a/provisioning_templates/provision/atomic_kickstart_default.erb
+++ b/provisioning_templates/provision/atomic_kickstart_default.erb
@@ -1,6 +1,7 @@
 <%#
 kind: provision
 name: Atomic Kickstart default
+model: ProvisioningTemplate
 %>
 
 lang <%= host_param('lang') || 'en_US.UTF-8' %>

--- a/provisioning_templates/provision/autoyast_default.erb
+++ b/provisioning_templates/provision/autoyast_default.erb
@@ -2,6 +2,7 @@
 <%#
 kind: provision
 name: AutoYaST default
+model: ProvisioningTemplate
 oses:
 - OpenSUSE
 -%>

--- a/provisioning_templates/provision/autoyast_sles_default.erb
+++ b/provisioning_templates/provision/autoyast_sles_default.erb
@@ -2,6 +2,7 @@
 <%#
 kind: provision
 name: AutoYaST SLES default
+model: ProvisioningTemplate
 oses:
 - SLES
 -%>

--- a/provisioning_templates/provision/coreos_provision.erb
+++ b/provisioning_templates/provision/coreos_provision.erb
@@ -2,6 +2,7 @@
 <%#
 kind: provision
 name: CoreOS provision
+model: ProvisioningTemplate
 oses:
 - CoreOS
 %>

--- a/provisioning_templates/provision/freebsd_(mfsbsd)_provision.erb
+++ b/provisioning_templates/provision/freebsd_(mfsbsd)_provision.erb
@@ -1,6 +1,7 @@
 <%#
 kind: provision
 name: FreeBSD (mfsBSD) provision
+model: ProvisioningTemplate
 oses:
 - FreeBSD
 %>

--- a/provisioning_templates/provision/jumpstart_default.erb
+++ b/provisioning_templates/provision/jumpstart_default.erb
@@ -1,6 +1,7 @@
 <%#
 kind: provision
 name: Jumpstart default
+model: ProvisioningTemplate
 %>
 install_type <%= @install_type %>
 partitioning explicit

--- a/provisioning_templates/provision/junos_default_slax.erb
+++ b/provisioning_templates/provision/junos_default_slax.erb
@@ -1,6 +1,7 @@
 <%#
 kind: provision
 name: Junos default SLAX
+model: ProvisioningTemplate
 -%>
 version 1.0;
 

--- a/provisioning_templates/provision/kickstart_default.erb
+++ b/provisioning_templates/provision/kickstart_default.erb
@@ -1,6 +1,7 @@
 <%#
 kind: provision
 name: Kickstart default
+model: ProvisioningTemplate
 oses:
 - CentOS
 - Fedora

--- a/provisioning_templates/provision/kickstart_rhel_default.erb
+++ b/provisioning_templates/provision/kickstart_rhel_default.erb
@@ -1,6 +1,7 @@
 <%#
 kind: provision
 name: Kickstart RHEL default
+model: ProvisioningTemplate
 oses:
 - RedHat
 %>

--- a/provisioning_templates/provision/preseed_default.erb
+++ b/provisioning_templates/provision/preseed_default.erb
@@ -1,6 +1,7 @@
 <%#
 kind: provision
 name: Preseed default
+model: ProvisioningTemplate
 oses:
 - Debian
 - Ubuntu

--- a/provisioning_templates/provision/xenserver_default_answerfile.erb
+++ b/provisioning_templates/provision/xenserver_default_answerfile.erb
@@ -1,6 +1,7 @@
 <%#
 kind: provision
 name: XenServer default answerfile
+model: ProvisioningTemplate
 oses:
 - XenServer
 -%>

--- a/provisioning_templates/script/grubby_default.erb
+++ b/provisioning_templates/script/grubby_default.erb
@@ -2,6 +2,7 @@
 <%#
 kind: script
 name: Grubby default
+model: ProvisioningTemplate
 %>
 
 KERNEL="/boot/kernel"

--- a/provisioning_templates/snippet/alterator_pkglist.erb
+++ b/provisioning_templates/snippet/alterator_pkglist.erb
@@ -1,6 +1,7 @@
 <%#
 kind: snippet
 name: alterator_pkglist
+model: ProvisioningTemplate
 -%>
 <%# 
   This template will not function with Safemode set to true. 

--- a/provisioning_templates/snippet/alterator_pkglist.erb
+++ b/provisioning_templates/snippet/alterator_pkglist.erb
@@ -2,6 +2,7 @@
 kind: snippet
 name: alterator_pkglist
 model: ProvisioningTemplate
+snippet: true
 -%>
 <%# 
   This template will not function with Safemode set to true. 

--- a/provisioning_templates/snippet/ansible_provisioning_callback.erb
+++ b/provisioning_templates/snippet/ansible_provisioning_callback.erb
@@ -2,6 +2,7 @@
 kind: snippet
 name: ansible_provisioning_callback
 model: ProvisioningTemplate
+snippet: true
 -%>
 <% if host_param_true?('ansible_tower_provisioning') -%>
 <%

--- a/provisioning_templates/snippet/ansible_provisioning_callback.erb
+++ b/provisioning_templates/snippet/ansible_provisioning_callback.erb
@@ -1,6 +1,7 @@
 <%#
 kind: snippet
 name: ansible_provisioning_callback
+model: ProvisioningTemplate
 -%>
 <% if host_param_true?('ansible_tower_provisioning') -%>
 <%

--- a/provisioning_templates/snippet/ansible_tower_callback_script.erb
+++ b/provisioning_templates/snippet/ansible_tower_callback_script.erb
@@ -2,6 +2,7 @@
 kind: snippet
 name: ansible_tower_callback_script
 model: ProvisioningTemplate
+snippet: true
 -%>
 #!/bin/sh
 

--- a/provisioning_templates/snippet/ansible_tower_callback_script.erb
+++ b/provisioning_templates/snippet/ansible_tower_callback_script.erb
@@ -1,6 +1,7 @@
 <%#
 kind: snippet
 name: ansible_tower_callback_script
+model: ProvisioningTemplate
 -%>
 #!/bin/sh
 

--- a/provisioning_templates/snippet/ansible_tower_callback_service.erb
+++ b/provisioning_templates/snippet/ansible_tower_callback_service.erb
@@ -1,6 +1,7 @@
 <%#
 kind: snippet
 name: ansible_tower_callback_service
+model: ProvisioningTemplate
 -%>
 [Unit]
 Description=Provisioning callback to Ansible Tower

--- a/provisioning_templates/snippet/ansible_tower_callback_service.erb
+++ b/provisioning_templates/snippet/ansible_tower_callback_service.erb
@@ -2,6 +2,7 @@
 kind: snippet
 name: ansible_tower_callback_service
 model: ProvisioningTemplate
+snippet: true
 -%>
 [Unit]
 Description=Provisioning callback to Ansible Tower

--- a/provisioning_templates/snippet/bmc_nic_setup.erb
+++ b/provisioning_templates/snippet/bmc_nic_setup.erb
@@ -1,6 +1,7 @@
 <%#
 kind: snippet
 name: bmc_nic_setup
+model: ProvisioningTemplate
 %>
 <%#
 # bmc_nic_setup snippet

--- a/provisioning_templates/snippet/bmc_nic_setup.erb
+++ b/provisioning_templates/snippet/bmc_nic_setup.erb
@@ -2,6 +2,7 @@
 kind: snippet
 name: bmc_nic_setup
 model: ProvisioningTemplate
+snippet: true
 %>
 <%#
 # bmc_nic_setup snippet

--- a/provisioning_templates/snippet/chef_client.erb
+++ b/provisioning_templates/snippet/chef_client.erb
@@ -1,6 +1,7 @@
 <%#
 kind: snippet
 name: chef_client
+model: ProvisioningTemplate
 description: this is a single entry point for chef-client bootstrapping, it selects
     a bootstrapping strategy based on host parameter named "chef_bootstrap_template"
     note that it can be set per hostgroup, os, domain etc.

--- a/provisioning_templates/snippet/chef_client.erb
+++ b/provisioning_templates/snippet/chef_client.erb
@@ -2,6 +2,7 @@
 kind: snippet
 name: chef_client
 model: ProvisioningTemplate
+snippet: true
 description: this is a single entry point for chef-client bootstrapping, it selects
     a bootstrapping strategy based on host parameter named "chef_bootstrap_template"
     note that it can be set per hostgroup, os, domain etc.

--- a/provisioning_templates/snippet/coreos_cloudconfig.erb
+++ b/provisioning_templates/snippet/coreos_cloudconfig.erb
@@ -2,6 +2,7 @@
 <%#
 kind: snippet
 name: coreos_cloudconfig
+model: ProvisioningTemplate
 %>
 <%
   units = 0

--- a/provisioning_templates/snippet/coreos_cloudconfig.erb
+++ b/provisioning_templates/snippet/coreos_cloudconfig.erb
@@ -3,6 +3,7 @@
 kind: snippet
 name: coreos_cloudconfig
 model: ProvisioningTemplate
+snippet: true
 %>
 <%
   units = 0

--- a/provisioning_templates/snippet/create_users.erb
+++ b/provisioning_templates/snippet/create_users.erb
@@ -1,5 +1,6 @@
 <%#
 name: create_users
+model: ProvisioningTemplate
 kind: snippet
 snippet: true
 -%>

--- a/provisioning_templates/snippet/epel.erb
+++ b/provisioning_templates/snippet/epel.erb
@@ -1,6 +1,7 @@
 <%#
 kind: snippet
 name: epel
+model: ProvisioningTemplate
 -%>
 <%
 repo_base  = host_param('epel-repo-base') ? host_param('epel-repo-base') : 'https://dl.fedoraproject.org/pub/epel'

--- a/provisioning_templates/snippet/epel.erb
+++ b/provisioning_templates/snippet/epel.erb
@@ -2,6 +2,7 @@
 kind: snippet
 name: epel
 model: ProvisioningTemplate
+snippet: true
 -%>
 <%
 repo_base  = host_param('epel-repo-base') ? host_param('epel-repo-base') : 'https://dl.fedoraproject.org/pub/epel'

--- a/provisioning_templates/snippet/fix_hosts.erb
+++ b/provisioning_templates/snippet/fix_hosts.erb
@@ -2,6 +2,7 @@
 kind: snippet
 name: fix_hosts
 model: ProvisioningTemplate
+snippet: true
 %>
 echo "<%= @host.shortname %>" > /etc/hostname
 hostname <%= @host.shortname %>

--- a/provisioning_templates/snippet/fix_hosts.erb
+++ b/provisioning_templates/snippet/fix_hosts.erb
@@ -1,6 +1,7 @@
 <%#
 kind: snippet
 name: fix_hosts
+model: ProvisioningTemplate
 %>
 echo "<%= @host.shortname %>" > /etc/hostname
 hostname <%= @host.shortname %>

--- a/provisioning_templates/snippet/freeipa_register.erb
+++ b/provisioning_templates/snippet/freeipa_register.erb
@@ -1,6 +1,7 @@
 <%#
 kind: snippet
 name: freeipa_register
+model: ProvisioningTemplate
 %>
 # FreeIPA Registration Snippet
 #

--- a/provisioning_templates/snippet/freeipa_register.erb
+++ b/provisioning_templates/snippet/freeipa_register.erb
@@ -2,6 +2,7 @@
 kind: snippet
 name: freeipa_register
 model: ProvisioningTemplate
+snippet: true
 %>
 # FreeIPA Registration Snippet
 #

--- a/provisioning_templates/snippet/http_proxy.erb
+++ b/provisioning_templates/snippet/http_proxy.erb
@@ -2,6 +2,7 @@
 kind: snippet
 name: http_proxy
 model: ProvisioningTemplate
+snippet: true
 %>
 <% if (proxy = host_param("http_proxy")) -%>
 http_proxy=<%= proxy %>

--- a/provisioning_templates/snippet/http_proxy.erb
+++ b/provisioning_templates/snippet/http_proxy.erb
@@ -1,6 +1,7 @@
 <%#
 kind: snippet
 name: http_proxy
+model: ProvisioningTemplate
 %>
 <% if (proxy = host_param("http_proxy")) -%>
 http_proxy=<%= proxy %>

--- a/provisioning_templates/snippet/kickstart_ifcfg_bond_interface.erb
+++ b/provisioning_templates/snippet/kickstart_ifcfg_bond_interface.erb
@@ -1,5 +1,6 @@
 <%#
 name: kickstart_ifcfg_bond_interface
+model: ProvisioningTemplate
 snippet: true
 model: ProvisioningTemplate
 kind: snippet

--- a/provisioning_templates/snippet/kickstart_ifcfg_bonded_interface.erb
+++ b/provisioning_templates/snippet/kickstart_ifcfg_bonded_interface.erb
@@ -1,5 +1,6 @@
 <%#
 name: kickstart_ifcfg_bonded_interface
+model: ProvisioningTemplate
 snippet: true
 model: ProvisioningTemplate
 kind: snippet

--- a/provisioning_templates/snippet/kickstart_ifcfg_generic_interface.erb
+++ b/provisioning_templates/snippet/kickstart_ifcfg_generic_interface.erb
@@ -1,5 +1,6 @@
 <%#
 name: kickstart_ifcfg_generic_interface
+model: ProvisioningTemplate
 snippet: true
 model: ProvisioningTemplate
 kind: snippet

--- a/provisioning_templates/snippet/kickstart_ifcfg_get_identifier_names.erb
+++ b/provisioning_templates/snippet/kickstart_ifcfg_get_identifier_names.erb
@@ -1,5 +1,6 @@
 <%#
 name: kickstart_ifcfg_get_identifier_names
+model: ProvisioningTemplate
 snippet: true
 model: ProvisioningTemplate
 kind: snippet

--- a/provisioning_templates/snippet/kickstart_networking_setup.erb
+++ b/provisioning_templates/snippet/kickstart_networking_setup.erb
@@ -1,5 +1,6 @@
 <%#
 name: kickstart_networking_setup
+model: ProvisioningTemplate
 snippet: true
 model: ProvisioningTemplate
 kind: snippet

--- a/provisioning_templates/snippet/preseed_networking_setup.erb
+++ b/provisioning_templates/snippet/preseed_networking_setup.erb
@@ -2,6 +2,7 @@
 kind: snippet
 name: preseed_networking_setup
 model: ProvisioningTemplate
+snippet: true
 description: this will configure your host networking, it configures your primary interface as well
     as other configures NICs. It supports physical, VLAN and Alias interfaces. It's intended to be
     called in your preseed finish template.

--- a/provisioning_templates/snippet/preseed_networking_setup.erb
+++ b/provisioning_templates/snippet/preseed_networking_setup.erb
@@ -1,6 +1,7 @@
 <%#
 kind: snippet
 name: preseed_networking_setup
+model: ProvisioningTemplate
 description: this will configure your host networking, it configures your primary interface as well
     as other configures NICs. It supports physical, VLAN and Alias interfaces. It's intended to be
     called in your preseed finish template.

--- a/provisioning_templates/snippet/puppet.conf.erb
+++ b/provisioning_templates/snippet/puppet.conf.erb
@@ -2,6 +2,7 @@
 kind: snippet
 name: puppet.conf
 model: ProvisioningTemplate
+snippet: true
 %>
 <%
   os_family = @host.operatingsystem.family

--- a/provisioning_templates/snippet/puppet.conf.erb
+++ b/provisioning_templates/snippet/puppet.conf.erb
@@ -1,6 +1,7 @@
 <%#
 kind: snippet
 name: puppet.conf
+model: ProvisioningTemplate
 %>
 <%
   os_family = @host.operatingsystem.family

--- a/provisioning_templates/snippet/puppet_setup.erb
+++ b/provisioning_templates/snippet/puppet_setup.erb
@@ -1,6 +1,7 @@
 <%#
 kind: snippet
 name: puppet_setup
+model: ProvisioningTemplate
 description: this snippet will configure the Puppet agent
 %>
 <%

--- a/provisioning_templates/snippet/puppet_setup.erb
+++ b/provisioning_templates/snippet/puppet_setup.erb
@@ -3,6 +3,7 @@ kind: snippet
 name: puppet_setup
 model: ProvisioningTemplate
 description: this snippet will configure the Puppet agent
+snippet: true
 %>
 <%
 os_family = @host.operatingsystem.family

--- a/provisioning_templates/snippet/puppetlabs_repo.erb
+++ b/provisioning_templates/snippet/puppetlabs_repo.erb
@@ -2,6 +2,7 @@
 kind: snippet
 name: puppetlabs_repo
 model: ProvisioningTemplate
+snippet: true
 -%>
 <%
 http_proxy   = host_param('http-proxy') ? " --httpproxy #{host_param('http-proxy')}" : nil

--- a/provisioning_templates/snippet/puppetlabs_repo.erb
+++ b/provisioning_templates/snippet/puppetlabs_repo.erb
@@ -1,6 +1,7 @@
 <%#
 kind: snippet
 name: puppetlabs_repo
+model: ProvisioningTemplate
 -%>
 <%
 http_proxy   = host_param('http-proxy') ? " --httpproxy #{host_param('http-proxy')}" : nil

--- a/provisioning_templates/snippet/pxegrub2_chainload.erb
+++ b/provisioning_templates/snippet/pxegrub2_chainload.erb
@@ -1,6 +1,7 @@
 <%#
 kind: snippet
 name: pxegrub2_chainload
+model: ProvisioningTemplate
 %>
 <%
   paths = ["fedora", "redhat", "centos", "debian", "ubuntu", "Microsoft", "EFI"]

--- a/provisioning_templates/snippet/pxegrub2_chainload.erb
+++ b/provisioning_templates/snippet/pxegrub2_chainload.erb
@@ -2,6 +2,7 @@
 kind: snippet
 name: pxegrub2_chainload
 model: ProvisioningTemplate
+snippet: true
 %>
 <%
   paths = ["fedora", "redhat", "centos", "debian", "ubuntu", "Microsoft", "EFI"]

--- a/provisioning_templates/snippet/pxegrub2_discovery.erb
+++ b/provisioning_templates/snippet/pxegrub2_discovery.erb
@@ -1,6 +1,7 @@
 <%#
 kind: snippet
 name: pxegrub2_discovery
+model: ProvisioningTemplate
 -%>
 <%#
 RHEL 7 virtio driver does not have persistent naming scheme, causing interfaces

--- a/provisioning_templates/snippet/pxegrub2_discovery.erb
+++ b/provisioning_templates/snippet/pxegrub2_discovery.erb
@@ -2,6 +2,7 @@
 kind: snippet
 name: pxegrub2_discovery
 model: ProvisioningTemplate
+snippet: true
 -%>
 <%#
 RHEL 7 virtio driver does not have persistent naming scheme, causing interfaces

--- a/provisioning_templates/snippet/pxegrub_chainload.erb
+++ b/provisioning_templates/snippet/pxegrub_chainload.erb
@@ -2,6 +2,7 @@
 kind: snippet
 name: pxegrub_chainload
 model: ProvisioningTemplate
+snippet: true
 %>
 <%
   paths = ["fedora", "redhat", "centos", "debian", "ubuntu", "Microsoft", "EFI"]

--- a/provisioning_templates/snippet/pxegrub_chainload.erb
+++ b/provisioning_templates/snippet/pxegrub_chainload.erb
@@ -1,6 +1,7 @@
 <%#
 kind: snippet
 name: pxegrub_chainload
+model: ProvisioningTemplate
 %>
 <%
   paths = ["fedora", "redhat", "centos", "debian", "ubuntu", "Microsoft", "EFI"]

--- a/provisioning_templates/snippet/pxegrub_discovery.erb
+++ b/provisioning_templates/snippet/pxegrub_discovery.erb
@@ -2,6 +2,7 @@
 kind: snippet
 name: pxegrub_discovery
 model: ProvisioningTemplate
+snippet: true
 -%>
 <%#
 RHEL 7 virtio driver does not have persistent naming scheme, causing interfaces

--- a/provisioning_templates/snippet/pxegrub_discovery.erb
+++ b/provisioning_templates/snippet/pxegrub_discovery.erb
@@ -1,6 +1,7 @@
 <%#
 kind: snippet
 name: pxegrub_discovery
+model: ProvisioningTemplate
 -%>
 <%#
 RHEL 7 virtio driver does not have persistent naming scheme, causing interfaces

--- a/provisioning_templates/snippet/pxelinux_chainload.erb
+++ b/provisioning_templates/snippet/pxelinux_chainload.erb
@@ -1,6 +1,7 @@
 <%#
 kind: snippet
 name: pxelinux_chainload
+model: ProvisioningTemplate
 %>
 LABEL local
   MENU LABEL Default local boot

--- a/provisioning_templates/snippet/pxelinux_chainload.erb
+++ b/provisioning_templates/snippet/pxelinux_chainload.erb
@@ -2,6 +2,7 @@
 kind: snippet
 name: pxelinux_chainload
 model: ProvisioningTemplate
+snippet: true
 %>
 LABEL local
   MENU LABEL Default local boot

--- a/provisioning_templates/snippet/pxelinux_discovery.erb
+++ b/provisioning_templates/snippet/pxelinux_discovery.erb
@@ -1,6 +1,7 @@
 <%#
 kind: snippet
 name: pxelinux_discovery
+model: ProvisioningTemplate
 -%>
 <%#
 discovery image is based on CentOS/RHEL and therefor it is affected by https://bugzilla.redhat.com/show_bug.cgi?id=1259015.

--- a/provisioning_templates/snippet/pxelinux_discovery.erb
+++ b/provisioning_templates/snippet/pxelinux_discovery.erb
@@ -2,6 +2,7 @@
 kind: snippet
 name: pxelinux_discovery
 model: ProvisioningTemplate
+snippet: true
 -%>
 <%#
 discovery image is based on CentOS/RHEL and therefor it is affected by https://bugzilla.redhat.com/show_bug.cgi?id=1259015.

--- a/provisioning_templates/snippet/redhat_register.erb
+++ b/provisioning_templates/snippet/redhat_register.erb
@@ -2,6 +2,7 @@
 kind: snippet
 name: redhat_register
 model: ProvisioningTemplate
+snippet: true
 %>
 # Red Hat Registration Snippet
 #

--- a/provisioning_templates/snippet/redhat_register.erb
+++ b/provisioning_templates/snippet/redhat_register.erb
@@ -1,6 +1,7 @@
 <%#
 kind: snippet
 name: redhat_register
+model: ProvisioningTemplate
 %>
 # Red Hat Registration Snippet
 #

--- a/provisioning_templates/snippet/remote_execution_ssh_keys.erb
+++ b/provisioning_templates/snippet/remote_execution_ssh_keys.erb
@@ -2,6 +2,7 @@
 kind: snippet
 name: remote_execution_ssh_keys
 model: ProvisioningTemplate
+snippet: true
 %>
 # SSH keys setup snippet for Remote Execution plugin
 #

--- a/provisioning_templates/snippet/remote_execution_ssh_keys.erb
+++ b/provisioning_templates/snippet/remote_execution_ssh_keys.erb
@@ -1,6 +1,7 @@
 <%#
-  kind: snippet
-  name: remote_execution_ssh_keys
+kind: snippet
+name: remote_execution_ssh_keys
+model: ProvisioningTemplate
 %>
 # SSH keys setup snippet for Remote Execution plugin
 #

--- a/provisioning_templates/snippet/saltstack_minion.erb
+++ b/provisioning_templates/snippet/saltstack_minion.erb
@@ -1,6 +1,7 @@
 <%#
 kind: snippet
 name: saltstack_minion
+model: ProvisioningTemplate
 %>
 master: <%= host_param('salt_master') %>
 log_level: warning

--- a/provisioning_templates/snippet/saltstack_minion.erb
+++ b/provisioning_templates/snippet/saltstack_minion.erb
@@ -2,6 +2,7 @@
 kind: snippet
 name: saltstack_minion
 model: ProvisioningTemplate
+snippet: true
 %>
 master: <%= host_param('salt_master') %>
 log_level: warning

--- a/provisioning_templates/snippet/saltstack_setup.erb
+++ b/provisioning_templates/snippet/saltstack_setup.erb
@@ -1,6 +1,7 @@
 <%#
 kind: snippet
 name: saltstack_setup
+model: ProvisioningTemplate
 description: this snippet will configure the Saltstack Minion
 %>
 <%

--- a/provisioning_templates/snippet/saltstack_setup.erb
+++ b/provisioning_templates/snippet/saltstack_setup.erb
@@ -3,6 +3,7 @@ kind: snippet
 name: saltstack_setup
 model: ProvisioningTemplate
 description: this snippet will configure the Saltstack Minion
+snippet: true
 %>
 <%
 etc_path = (@host.operatingsystem.family == 'Freebsd') ? '/usr/local/etc/salt' : '/etc/salt'

--- a/provisioning_templates/user_data/autoyast_default_user_data.erb
+++ b/provisioning_templates/user_data/autoyast_default_user_data.erb
@@ -1,6 +1,7 @@
 <%#
 kind: user_data
 name: AutoYaST default user data
+model: ProvisioningTemplate
 oses:
 - OpenSUSE
 - SLES

--- a/provisioning_templates/user_data/kickstart_default_user_data.erb
+++ b/provisioning_templates/user_data/kickstart_default_user_data.erb
@@ -1,6 +1,7 @@
 <%#
 kind: user_data
 name: Kickstart default user data
+model: ProvisioningTemplate
 oses:
 - CentOS
 - Fedora

--- a/provisioning_templates/user_data/preseed_default_user_data.erb
+++ b/provisioning_templates/user_data/preseed_default_user_data.erb
@@ -1,6 +1,7 @@
 <%#
 kind: user_data
 name: Preseed default user data
+model: ProvisioningTemplate
 oses:
 - Debian
 - Ubuntu

--- a/provisioning_templates/user_data/userdata_default.erb
+++ b/provisioning_templates/user_data/userdata_default.erb
@@ -1,6 +1,7 @@
 <%#
 kind: user_data
 name: UserData default
+model: ProvisioningTemplate
 oses:
 - CentOS
 - Fedora

--- a/test/common/headers_test.rb
+++ b/test/common/headers_test.rb
@@ -11,10 +11,12 @@ class TestHeaders < Minitest::Test
       refute_nil extracted
       yaml = YAML.load(extracted[1])
       refute_nil yaml
-      refute_nil yaml['kind']
-      refute_empty yaml['kind']
-      refute_nil yaml['name']
-      refute_empty yaml['name']
+      refute_nil yaml['kind'], "#{erb} metadata does not contain kind attribute"
+      refute_empty yaml['kind'], "#{erb} metadata kind attribute is empty"
+      refute_nil yaml['name'], "#{erb} metadata does not contain name attribute"
+      refute_empty yaml['name'], "#{erb} metadata name attribute is empty"
+      refute_nil yaml['model'], "#{erb} metadata does not contain model attribute"
+      refute_empty yaml['model'], "#{erb} metadata model attribute is empty"
     end
   end
 end


### PR DESCRIPTION
Foreman adds model attribute to metadata during export, which makes it easier to import the template later just from file without further knowledge. It's useful in foreman_templates. I updated all templates in this repo to contain this attribute too, plus added a test that ensures all new templates have this attribute filled. As a small bonus, I updated failure message for this and similar tests.

It would be great to get this in early since the PR will get out of date easily.