### PR TITLE
Use os_family instead of os_name to verify if it's a Suse based OS

### DIFF
--- a/provisioning_templates/snippet/puppet.conf.erb
+++ b/provisioning_templates/snippet/puppet.conf.erb
@@ -9,7 +9,7 @@ snippet: true
   os_name   = @host.operatingsystem.name
 
   aio_enabled = host_param_true?('enable-puppetlabs-puppet5-repo') || host_param_true?('enable-puppetlabs-pc1-repo') || host_param_true?('enable-puppet4') || host_param_true?('enable-puppet5')
-  aio_available = os_family == 'Debian' || os_family == 'Redhat' || os_name == 'SLES'
+  aio_available = os_family == 'Debian' || os_family == 'Redhat' || os_family == 'Suse'
 
   if aio_enabled && aio_available
     var_dir = '/opt/puppetlabs/puppet/cache'

--- a/provisioning_templates/snippet/puppetlabs_repo.erb
+++ b/provisioning_templates/snippet/puppetlabs_repo.erb
@@ -44,7 +44,7 @@ repo_subdir = host_param_true?('enable-puppetlabs-puppet5-repo') ? 'puppet5/' : 
 -%>
 
 <% if repo_name -%>
-<% if os_family == 'Redhat' || os_name == 'SLES' -%>
+<% if os_family == 'Redhat' || os_family == 'Suse' -%>
 rpm -Uvh<%= http_proxy %><%= http_port %> https://<%= repo_host %>/<%= repo_subdir %><%= repo_name %>-<%= repo_os %>-<%= os_major %>.noarch.rpm
 <% elsif os_family == 'Debian' -%>
 apt-get update


### PR DESCRIPTION
In case enable-puppetlabs-X-repo is set we need to adjust the path.