### PR TITLE
Kickstart: Add --no-proxy to informing Foreman

### DIFF
--- a/provisioning_templates/provision/kickstart_default.erb
+++ b/provisioning_templates/provision/kickstart_default.erb
@@ -199,7 +199,7 @@ sync
 
 # Inform the build system that we are done.
 echo "Informing Foreman that we are built"
-wget -q -O /dev/null --no-check-certificate <%= foreman_url('built') %>
+wget -q -O /dev/null --no-proxy --no-check-certificate <%= foreman_url('built') %>
 ) 2>&1 | tee /root/install.post.log
 exit 0
 

--- a/provisioning_templates/provision/kickstart_rhel_default.erb
+++ b/provisioning_templates/provision/kickstart_rhel_default.erb
@@ -173,7 +173,7 @@ sync
 
 # Inform the build system that we are done.
 echo "Informing Foreman that we are built"
-wget -q -O /dev/null --no-check-certificate <%= foreman_url('built') %>
+wget -q -O /dev/null --no-proxy --no-check-certificate <%= foreman_url('built') %>
 ) 2>&1 | tee /root/install.post.log
 exit 0
 


### PR DESCRIPTION
I ran into the problem last week that Kickstart provisioning with proxy set does not inform Foreman when it is built as it tries to use the proxy also for this request. I think adding `--no-proxy` to it is ok as having a proxy between the provisioned system and Foreman is not a common scenario and probably will not work at all. We could also add another parameter to not break such a scenario, but I would like to avoid this for simplicity. I am not sure if other operating systems would benefit from a similar fix. 