### PR TITLE
Update CoreOS Container Linux PXE template

### DIFF
--- a/provisioning_templates/PXELinux/coreos_pxelinux.erb
+++ b/provisioning_templates/PXELinux/coreos_pxelinux.erb
@@ -6,7 +6,13 @@ oses:
 - CoreOS
 %>
 DEFAULT coreos
+PROMPT 1
+TIMEOUT 15
+
+DISPLAY boot.msg
 
 LABEL coreos
-    KERNEL <%= @kernel %>
-    APPEND initrd=<%= @initrd %> cloud-config-url=<%= foreman_url('provision')%>
+  MENU default
+  KERNEL <%= @kernel %>
+  INITRD <%= @initrd %>
+  APPEND coreos.first_boot=1 coreos.config.url=<%= foreman_url('provision') %>


### PR DESCRIPTION
As you can see in https://coreos.com/os/docs/latest/booting-with-pxe.html

An update to the provisioning template should also follow, so that it uses ignition (or ct for transpiling the yaml)... any preferences @timogoebel ?