### PR TITLE
Add feature to default roles playbook

### DIFF
--- a/job_templates/ansible_roles_-_ansible_default.erb
+++ b/job_templates/ansible_roles_-_ansible_default.erb
@@ -2,6 +2,7 @@
 name: Ansible Roles - Ansible Default
 job_category: Ansible Playbook
 description_format: Run Ansible roles
+feature: ansible_run_host
 snippet: false
 provider_type: Ansible
 kind: job_template


### PR DESCRIPTION
This playbook is used for the ansible_run_host. Currently I'm adding this line on every sync, but it should not be necessary.