### PR TITLE
Put Ansible Power & Puppet jobs into separate categories

### DIFF
--- a/job_templates/power_action_-_ansible_default.erb
+++ b/job_templates/power_action_-_ansible_default.erb
@@ -1,6 +1,6 @@
 <%#
 name: Power Action - Ansible Default
-job_category: Power
+job_category: Ansible Power
 description_format: "%{action} host"
 snippet: false
 template_inputs:

--- a/job_templates/puppet_run_once_-_ansible_default.erb
+++ b/job_templates/puppet_run_once_-_ansible_default.erb
@@ -1,6 +1,6 @@
 <%#
 name: Puppet Run Once - Ansible Default
-job_category: Puppet
+job_category: Ansible Puppet
 description_format: 'Run Puppet once with "%{puppet_options}"'
 snippet: false
 template_inputs:


### PR DESCRIPTION
Ansible jobs that share a category with Puppet jobs need their
own category to avoid an issue when invoking a job, where it
shows duplicate inputs for jobs template and parameters.

Before:
![screenshot_2018-03-30_11-26-19](https://user-images.githubusercontent.com/7757/38134860-525e39d8-3415-11e8-888b-c015dd8f558f.png)

After:

![screenshot_2018-03-30_12-24-01](https://user-images.githubusercontent.com/7757/38134874-5c19622c-3415-11e8-9496-418e2aaef332.png)
![screenshot_2018-03-30_12-24-17](https://user-images.githubusercontent.com/7757/38134875-5c359212-3415-11e8-9230-12fdf128d1f9.png)
