### PR TITLE
Align Ansible "Services" category wording

### DIFF
--- a/job_templates/service_action_-_ansible_default.erb
+++ b/job_templates/service_action_-_ansible_default.erb
@@ -1,6 +1,6 @@
 <%#
 name: Service Action - Ansible Default
-job_category: Ansible Service
+job_category: Ansible Services
 description_format: "%{state} service %{name}"
 snippet: false
 template_inputs:


### PR DESCRIPTION
Just a minor wording fix to align with job category wording of the SSH Default Service Action.