### PR TITLE
Refs #23210 - Provision PuppetCA-Token on Host

### DIFF
--- a/provisioning_templates/snippet/csr_attributes.yaml.erb
+++ b/provisioning_templates/snippet/csr_attributes.yaml.erb
@@ -1,0 +1,9 @@
+<%#
+kind: snippet
+name: csr_attributes.yaml
+model: ProvisioningTemplate
+snippet: true
+%>
+---
+custom_attributes:
+  1.2.840.113549.1.9.7: "<%= @host.puppetca_token.value %>"

--- a/provisioning_templates/snippet/puppet_setup.erb
+++ b/provisioning_templates/snippet/puppet_setup.erb
@@ -76,6 +76,17 @@ cat > <%= etc_path %>/puppet.conf << EOF
 EOF
 <% end -%>
 
+<% if @host.puppetca_token.present? -%>
+<% if os_family == 'Windows' -%>
+$csr_attributes = @("<%= snippet 'csr_attributes.yaml' %>".Replace("`n","`r`n"))
+Out-File -FilePath <%= etc_path %>\csr_attributes.yaml -InputObject $csr_attributes
+<% else -%>
+cat > <%= etc_path %>/csr_attributes.yaml << EOF
+<%= snippet 'csr_attributes.yaml' %>
+EOF
+<% end -%>
+<% end -%>
+
 <% if os_family == 'Redhat' -%>
 <% if os_major > 6 -%>
 puppet_unit=puppet


### PR DESCRIPTION
Adds the PuppetCA-Token that is generated by Foreman
on Host-Creation in puppet's csr_attributes.yaml,
so it is included in puppet's CSR to be verified.

See also PRs in [foreman-core](https://github.com/theforeman/foreman/pull/5465), [smart-proxy](https://github.com/theforeman/smart-proxy/pull/576), [puppet-foreman_proxy](https://github.com/theforeman/puppet-foreman_proxy/pull/425) & [puppet-puppet](https://github.com/theforeman/puppet-puppet/pull/591).

We would like to see some feedback early on while we are testing this thoroughly.
Especially we would like to see someone testing this on Windows as we cannot.