### PR TITLE
Fixes #24084 - root password hash propagation to authconfig

### DIFF
--- a/provisioning_templates/provision/kickstart_default.erb
+++ b/provisioning_templates/provision/kickstart_default.erb
@@ -69,9 +69,9 @@ firewall --disable
 firewall --<%= os_major >= 6 ? 'service=' : '' %>ssh
 <% end -%>
 <% if @host.operatingsystem.name == 'Fedora' && os_major >= 28 -%>
-authselect --useshadow --passalgo=<%= @host.operatingsystem.password_hash || 'sha256' %> --kickstart
+authselect --useshadow --passalgo=<%= @host.operatingsystem.password_hash.downcase || 'sha256' %> --kickstart
 <% else -%>
-authconfig --useshadow --passalgo=<%= @host.operatingsystem.password_hash || 'sha256' %> --kickstart
+authconfig --useshadow --passalgo=<%= @host.operatingsystem.password_hash.downcase || 'sha256' %> --kickstart
 <% end -%>
 timezone --utc <%= host_param('time-zone') || 'UTC' %>
 <% if rhel_compatible -%>


### PR DESCRIPTION
If SHA512 is used in host.operatingsystem.password_hash (SHA256 is the default in kickstart_default.erb), authconfig will use SHA256 anyway because it has no value SHA512 (but sha512).

As described in https://github.com/theforeman/foreman/pull/5746