### PR TITLE
Add more puppet job templates

### DIFF
--- a/job_templates/puppet_agent_disable_-_ssh_default.erb
+++ b/job_templates/puppet_agent_disable_-_ssh_default.erb
@@ -1,0 +1,16 @@
+<%#
+name: Puppet Agent Disable - SSH Default
+model: JobTemplate
+job_category: Puppet
+description_format: Disable Puppet agent
+snippet: false
+template_inputs:
+- name: comment
+  required: false
+  input_type: user
+  description: Reason for disabling the Puppet agent
+  advanced: false
+provider_type: SSH
+kind: job_template
+-%>
+puppet agent --disable "<%= input("comment").present? ? input("comment") : "Disabled using Foreman Remote Execution"  %> - <%= current_user %> - $(date "+%d/%m/%Y %H:%M")"

--- a/job_templates/puppet_agent_enable_-_ssh_default.erb
+++ b/job_templates/puppet_agent_enable_-_ssh_default.erb
@@ -1,0 +1,10 @@
+<%#
+name: Puppet Agent Enable - SSH Default
+model: JobTemplate
+job_category: Puppet
+description_format: Enable Puppet agent
+snippet: false
+provider_type: SSH
+kind: job_template
+-%>
+puppet agent --enable

--- a/job_templates/puppet_install_modules_from_forge_-_ssh_default.erb
+++ b/job_templates/puppet_install_modules_from_forge_-_ssh_default.erb
@@ -1,0 +1,36 @@
+<%#
+name: Puppet Module - Install from forge - SSH Default
+model: JobTemplate
+job_category: Puppet
+description_format: Install Puppet Module "%{puppet_module}" from forge
+snippet: false
+template_inputs:
+- name: puppet_module
+  required: true
+  input_type: user
+  description: Full name of the module, e.g. "puppetlabs-stdlib".
+  advanced: false
+- name: target_dir
+  required: false
+  input_type: user
+  description: The directory into which modules are installed, defaults to production environment.
+  advanced: false
+- name: version
+  required: false
+  input_type: user
+  description: Module version to install.
+  advanced: true
+- name: force
+  required: false
+  input_type: user
+  description: Force overwrite of existing module, if any. Type "true" to force.
+  advanced: true
+- name: ignore_dependencies
+  required: false
+  input_type: user
+  description: Do not attempt to install dependencies. Type "true" to ignore dependencies.
+  advanced: true
+provider_type: SSH
+kind: job_template
+-%>
+puppet module install <%= input('puppet_module') %> <%= "--target-dir #{input('target_dir')}" if input('target_dir').present? %> <%= "--version #{input('version')}" if input('version').present? %> <%= "--force" if input('force') == "true" %> <%= "--ignore-dependencies" if input('ignore_dependencies') == "true" %>

--- a/job_templates/puppet_install_modules_from_git_-_ssh_default.erb
+++ b/job_templates/puppet_install_modules_from_git_-_ssh_default.erb
@@ -1,0 +1,21 @@
+<%#
+name: Puppet Module - Install from git - SSH Default
+model: JobTemplate
+job_category: Puppet
+description_format: Install Puppet Module "%{puppet_module}" from git
+snippet: false
+template_inputs:
+- name: git_repository
+  required: true
+  input_type: user
+  description: "URL to the git repository containing the module, e.g:\r\nhttps://github.com/theforeman/puppet-puppet"
+  advanced: false
+- name: target_dir
+  required: true
+  input_type: user
+  description: For example, '/etc/puppetlabs/code/environments/production/modules/puppet'.
+  advanced: false
+provider_type: SSH
+kind: job_template
+-%>
+git clone <%= input('git_repository') %> <%= input('target_dir') %>


### PR DESCRIPTION
This pull request adds more puppet job templates.

* Disabling of the agent including a comment which should help the local admin to see why it was disabled. I also created a feature request to have a macro for the user executing the job to add it to the comment. (https://projects.theforeman.org/issues/23955)
* Enabling of the agent
* Installation of puppet modules to provide something similar to the ansible roles. For the Boolean options I created another feature request, for now I think forcing the user to type true is fine. (https://projects.theforeman.org/issues/23956)

I am not sure if the naming of the files is fine but I tried to align it to the other templates.