### PR TITLE
Refs #19389 - Use medium_provider framework

### DIFF
--- a/provisioning_templates/PXEGrub/kickstart_default_pxegrub.erb
+++ b/provisioning_templates/PXEGrub/kickstart_default_pxegrub.erb
@@ -50,7 +50,7 @@ oses:
 
   # optional repository for Atomic
   if @host.operatingsystem.name.match(/Atomic/i)
-    options.push("inst.repo=#{@host.operatingsystem.medium_uri(@host)}")
+    options.push("inst.repo=#{medium_uri}")
   end
 
   if host_param('kickstart_liveimg')

--- a/provisioning_templates/PXEGrub2/kickstart_default_pxegrub2.erb
+++ b/provisioning_templates/PXEGrub2/kickstart_default_pxegrub2.erb
@@ -50,7 +50,7 @@ oses:
 
   # optional repository for Atomic
   if @host.operatingsystem.name.match(/Atomic/i)
-    options.push("inst.repo=#{@host.operatingsystem.medium_uri(@host)}")
+    options.push("inst.repo=#{medium_uri}")
   end
 
   if host_param('kickstart_liveimg')

--- a/provisioning_templates/PXELinux/alterator_default_pxelinux.erb
+++ b/provisioning_templates/PXELinux/alterator_default_pxelinux.erb
@@ -13,11 +13,10 @@ oses:
 <%
     metadata    = @host.token.nil? ? '?metadata=' : '&metadata='
     os          = @host.operatingsystem
-    mediumpath  = os.mediumpath @host
+    mediumpath  = os.mediumpath(medium_provider)
 -%>
 DEFAULT linux
 
 LABEL linux
     KERNEL <%= @kernel %>
     APPEND initrd=<%= @initrd %> stagename=altunat showopts ramdisk_size=150000 automatic=<%= mediumpath %>,directory:/altlinux/p<%= @host.operatingsystem.major %>/<%= @host.architecture %> ai curl=<%= foreman_url('provision')%><%= metadata %>
-

--- a/provisioning_templates/PXELinux/kickstart_default_pxelinux.erb
+++ b/provisioning_templates/PXELinux/kickstart_default_pxelinux.erb
@@ -50,7 +50,7 @@ oses:
 
   # optional repository for Atomic
   if @host.operatingsystem.name.match(/Atomic/i)
-    options.push("inst.repo=#{@host.operatingsystem.medium_uri(@host)}")
+    options.push("inst.repo=#{medium_uri}")
   end
 
   if host_param('kickstart_liveimg')

--- a/provisioning_templates/PXELinux/kickstart_ovirt_pxelinux.erb
+++ b/provisioning_templates/PXELinux/kickstart_ovirt_pxelinux.erb
@@ -10,5 +10,5 @@ DEFAULT rhvh
 
 LABEL rhvh
 KERNEL <%= @kernel %>
-APPEND initrd=<%= @initrd %> inst.ks=<%= foreman_url("provision") %> inst.stage2=<%= @host.operatingsystem.medium_uri(@host) %> local_boot_trigger=<%= foreman_url("built") %> intel_iommu=on
+APPEND initrd=<%= @initrd %> inst.ks=<%= foreman_url("provision") %> inst.stage2=<%= medium_uri %> local_boot_trigger=<%= foreman_url("built") %> intel_iommu=on
 IPAPPEND 2

--- a/provisioning_templates/iPXE/autoyast_default_ipxe.erb
+++ b/provisioning_templates/iPXE/autoyast_default_ipxe.erb
@@ -8,10 +8,10 @@ oses:
 - OpenSUSE
 %>
 
-<% boot_files_uris = @host.operatingsystem.boot_files_uri(@host.medium,@host.architecture) -%>
+<% boot_files_uris = @host.operatingsystem.boot_files_uri(medium_provider) -%>
 <% kernel = boot_files_uris[0] -%>
 <% initrd = boot_files_uris[1] -%>
 
-kernel <%= kernel %> initrd=initrd.img splash=silent install=<%=@host.os.medium_uri(@host)%> autoyast=<%= foreman_url('provision') %> text-mode=1 useDHCP=1
+kernel <%= kernel %> initrd=initrd.img splash=silent install=<%= medium_uri %> autoyast=<%= foreman_url('provision') %> text-mode=1 useDHCP=1
 initrd <%= initrd %>
 boot

--- a/provisioning_templates/iPXE/preseed_default_ipxe.erb
+++ b/provisioning_templates/iPXE/preseed_default_ipxe.erb
@@ -12,7 +12,7 @@ oses:
 <% else -%>
 <% keyboard_params = 'console-setup/ask_detect=false console-setup/layout=USA console-setup/variant=USA keyboard-configuration/layoutcode=us' -%>
 <% end -%>
-<% boot_files_uris = @host.operatingsystem.boot_files_uri(@host.medium,@host.architecture) -%>
+<% boot_files_uris = @host.operatingsystem.boot_files_uri(medium_provider) -%>
 <% kernel = boot_files_uris[0] -%>
 <% initrd = boot_files_uris[1] -%>
 <% static = @host.token.nil? ? '?static=yes' : '&static=yes' -%>

--- a/provisioning_templates/provision/atomic_kickstart_default.erb
+++ b/provisioning_templates/provision/atomic_kickstart_default.erb
@@ -28,12 +28,12 @@ bootloader --timeout=3
 text
 
 <% if @host.os.name.match /.*fedora.*/i -%>
-# Use @host.operatingsystem.medium_uri(@host)}/content/repo/ as the URL if you
+# Use medium_uri/content/repo/ as the URL if you
 # have set up a local installation media for Fedora
 <% fedora_atomic_url = host_param('atomic_refs_url') || "https://dl.fedoraproject.org/pub/fedora/linux/atomic/#{@host.os.major}/" %>
 ostreesetup --nogpg --osname=fedora-atomic --remote=fedora-atomic --url=<%= fedora_atomic_url %> --ref=fedora-atomic/f<%= @host.os.major %>/<%= @host.architecture %>/docker-host
 <% elsif @host.os.name.match /.*centos.*/i -%>
-ostreesetup --nogpg --osname=centos-atomic-host --remote=centos-atomic-host --url=<%= host_param_true?('atomic-upstream') ? "http://mirror.centos.org/centos/#{@host.os.major}/atomic/#{@host.architecture}/repo/" : @host.operatingsystem.medium_uri(@host) %> --ref=centos-atomic-host/<%= @host.os.major %>/<%= @host.architecture %>/standard
+ostreesetup --nogpg --osname=centos-atomic-host --remote=centos-atomic-host --url=<%= host_param_true?('atomic-upstream') ? "http://mirror.centos.org/centos/#{@host.os.major}/atomic/#{@host.architecture}/repo/" : medium_uri %> --ref=centos-atomic-host/<%= @host.os.major %>/<%= @host.architecture %>/standard
 <% else -%>
 ostreesetup --nogpg --osname=rhel-atomic-host --remote=rhel-atomic-host --url=file:///install/ostree --ref=rhel-atomic-host/<%= @host.os.major %>/<%= @host.architecture %>/standard
 <% end -%>

--- a/provisioning_templates/provision/kickstart_ovirt.erb
+++ b/provisioning_templates/provision/kickstart_ovirt.erb
@@ -42,7 +42,7 @@ liveimg_name = host_param('liveimg_name') || 'squashfs.img'
 if host_param('kt_activation_keys')
   liveimg_url = repository_url(liveimg_name, 'isos')
 else
-  liveimg_url = "#{@host.operatingsystem.medium_uri(@host)}/#{liveimg_name}"
+  liveimg_url = "#{medium_uri}/#{liveimg_name}"
 end
 %>
 


### PR DESCRIPTION
This commit modifies templates to use `medium_provider` framework introduced in https://github.com/theforeman/foreman/pull/5244.