### PR TITLE
Ansible shutdown with 1m delay so callback can return

### DIFF
--- a/job_templates/power_action_-_ansible_default.erb
+++ b/job_templates/power_action_-_ansible_default.erb
@@ -24,5 +24,5 @@ model: JobTemplate
           when 'restart'
             'shutdown -r +1'
           else
-            'shutdown -h now'
+            'shutdown -h +1'
           end %>


### PR DESCRIPTION
Delaying the shutdown 1 minute so the Ansible job can return and the job
invocation can be green. Otherwise 'shutdown' may work but the job
invocation will fail.