### PR TITLE
When booting UEFI, you will receive Kernel Panic

### DIFF
--- a/provisioning_templates/iPXE/autoyast_default_ipxe.erb
+++ b/provisioning_templates/iPXE/autoyast_default_ipxe.erb
@@ -12,6 +12,6 @@ oses:
 <% kernel = boot_files_uris[0] -%>
 <% initrd = boot_files_uris[1] -%>
 
-kernel <%= kernel %> splash=silent install=<%=@host.os.medium_uri(@host)%> autoyast=<%= foreman_url('provision') %> text-mode=1 useDHCP=1
+kernel <%= kernel %> initrd=initrd.img splash=silent install=<%=@host.os.medium_uri(@host)%> autoyast=<%= foreman_url('provision') %> text-mode=1 useDHCP=1
 initrd <%= initrd %>
 boot

--- a/provisioning_templates/iPXE/kickstart_default_ipxe.erb
+++ b/provisioning_templates/iPXE/kickstart_default_ipxe.erb
@@ -16,7 +16,7 @@ oses:
   <% static = (@host.token.nil? ? '?' : '&') + static_arg -%>
 <% end -%>
 
-kernel <%= "#{@host.url_for_boot(:kernel)}" %> ks=<%= foreman_url('provision')%><%= static %> ksdevice=<%= @host.mac %> network kssendmac ks.sendmac inst.ks.sendmac ip=${netX/ip} netmask=${netX/netmask} gateway=${netX/gateway} dns=${dns}
+kernel <%= "#{@host.url_for_boot(:kernel)}" %> initrd=initrd.img ks=<%= foreman_url('provision')%><%= static %> ksdevice=<%= @host.mac %> network kssendmac ks.sendmac inst.ks.sendmac ip=${netX/ip} netmask=${netX/netmask} gateway=${netX/gateway} dns=${dns}
 initrd <%= "#{@host.url_for_boot(:initrd)}" %>
 
 boot

--- a/provisioning_templates/iPXE/preseed_default_ipxe.erb
+++ b/provisioning_templates/iPXE/preseed_default_ipxe.erb
@@ -17,7 +17,7 @@ oses:
 <% initrd = boot_files_uris[1] -%>
 <% static = @host.token.nil? ? '?static=yes' : '&static=yes' -%>
 
-kernel <%= kernel %> interface=auto url=<%= foreman_url('provision')%><%= static %> ramdisk_size=10800 root=/dev/rd/0 rw auto netcfg/disable_dhcp=true BOOTIF=01-${netX/mac:hexhyp} hostname=<%= @host.name %> <%= keyboard_params %> locale=<%= host_param('lang') || 'en_US' %> netcfg/get_ipaddress=${netX/ip} netcfg/get_netmask=${netX/netmask} netcfg/get_gateway=${netX/gateway} netcfg/get_nameservers=${dns} netcfg/confirm_static=true
+kernel <%= kernel %> initrd=initrd.img interface=auto url=<%= foreman_url('provision')%><%= static %> ramdisk_size=10800 root=/dev/rd/0 rw auto netcfg/disable_dhcp=true BOOTIF=01-${netX/mac:hexhyp} hostname=<%= @host.name %> <%= keyboard_params %> locale=<%= host_param('lang') || 'en_US' %> netcfg/get_ipaddress=${netX/ip} netcfg/get_netmask=${netX/netmask} netcfg/get_gateway=${netX/gateway} netcfg/get_nameservers=${dns} netcfg/confirm_static=true
 initrd <%= initrd %>
 
 boot


### PR DESCRIPTION
Kernel panic - not syncing: VFS:  Unable to mount root fs on unknown-block(0,0) 

Unless you include initrd=initrd.img on the kernel line.  I have tested and this is safe for BIOS and UEFI booting.  Apparently, UEFI needs the location of the initrd.img to be specified or it cannot find it; unlike bios that seems to just look where the kernel is.  This works with bios RHEL 6 and 7, and with UEFI RHEL 7.  UEFI RHEL 6 gets an iPXE exec format error.  I have only tested with RHEL 6 and 7.