### PR TITLE
Add custom-snippet parameter

### DIFF
--- a/provisioning_templates/PXEGrub/kickstart_default_pxegrub.erb
+++ b/provisioning_templates/PXEGrub/kickstart_default_pxegrub.erb
@@ -67,3 +67,5 @@ title <%= template_name %>
   root (nd)
   kernel (nd)/../<%= @kernel %> ks=<%= foreman_url('provision') %> <%= pxe_kernel_options %> <%= ksoptions %>
   initrd (nd)/../<%= @initrd %>
+
+<%= snippet_if_exists(template_name + " custom menu") %>

--- a/provisioning_templates/PXEGrub2/kickstart_default_pxegrub2.erb
+++ b/provisioning_templates/PXEGrub2/kickstart_default_pxegrub2.erb
@@ -79,3 +79,5 @@ menuentry '<%= template_name %>' {
   <%= linuxcmd %> <%= @kernel %> ks=<%= foreman_url('provision') %> <%= pxe_kernel_options %> <%= ksoptions %>
   <%= initrdcmd %> <%= @initrd %>
 }
+
+<%= snippet_if_exists(template_name + " custom menu") %>

--- a/provisioning_templates/PXEGrub2/preseed_default_pxegrub2.erb
+++ b/provisioning_templates/PXEGrub2/preseed_default_pxegrub2.erb
@@ -51,3 +51,5 @@ menuentry '<%= template_name %>' {
   linux<%= efi_suffix %>  <%= @kernel %> interface=auto url=<%= foreman_url('provision')%> ramdisk_size=10800 root=/dev/rd/0 rw auto hostname=<%= @host.name %> <%= options %>
   initrd<%= efi_suffix %> <%= @initrd %>
 }
+
+<%= snippet_if_exists(template_name + " custom menu") %>

--- a/provisioning_templates/PXELinux/kickstart_default_pxelinux.erb
+++ b/provisioning_templates/PXELinux/kickstart_default_pxelinux.erb
@@ -72,3 +72,5 @@ LABEL installer
   KERNEL <%= @kernel %>
   APPEND initrd=<%= @initrd %> ks=<%= foreman_url('provision') %> <%= pxe_kernel_options %> <%= ksoptions %>
   IPAPPEND 2
+
+<%= snippet_if_exists(template_name + " custom menu") %>

--- a/provisioning_templates/PXELinux/preseed_default_pxelinux.erb
+++ b/provisioning_templates/PXELinux/preseed_default_pxelinux.erb
@@ -38,3 +38,5 @@ LABEL linux
     KERNEL <%= @kernel %>
     APPEND initrd=<%= @initrd %> interface=auto url=<%= foreman_url('provision')%> ramdisk_size=10800 root=/dev/rd/0 rw auto hostname=<%= @host.name %> <%= options %>
     IPAPPEND 2
+
+<%= snippet_if_exists(template_name + " custom menu") %>

--- a/provisioning_templates/finish/preseed_default_finish.erb
+++ b/provisioning_templates/finish/preseed_default_finish.erb
@@ -29,6 +29,7 @@ oses:
 /bin/hostname  <%= @host.shortname %>.<%= @host.domain %>
 <% end -%>
 
+<%= snippet_if_exists(template_name + " custom snippet") %>
 <% if host_enc['parameters']['realm'] && @host.realm && @host.realm.realm_type == 'FreeIPA' -%>
 <%= snippet 'freeipa_register' %>
 <% end -%>

--- a/provisioning_templates/provision/kickstart_default.erb
+++ b/provisioning_templates/provision/kickstart_default.erb
@@ -140,6 +140,7 @@ reboot
 <% end -%>
 
 %packages
+<%= snippet_if_exists(template_name + " custom packages") %>
 yum
 dhclient
 <% if use_ntp -%>
@@ -160,6 +161,7 @@ salt-minion
 
 <% if @dynamic -%>
 %pre
+<%= snippet_if_exists(template_name + " custom pre") %>
 <%= @host.diskLayout %>
 <%= section_end -%>
 <% end -%>
@@ -182,6 +184,7 @@ logger "Starting anaconda <%= @host %> postinstall"
 exec < /dev/tty3 > /dev/tty3
 #changing to VT 3 so that we can see whats going on....
 /usr/bin/chvt 3
+<%= snippet_if_exists(template_name + " custom post") %>
 <% if subnet.respond_to?(:dhcp_boot_mode?) || @host.subnet6.respond_to?(:dhcp_boot_mode?) -%>
 <%= snippet 'kickstart_networking_setup' %>
 <% end -%>

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -137,6 +137,14 @@ class FakeNamespace
     ''
   end
 
+  def snippet_if_exists(*args)
+    ''
+  end
+
+  def template_name
+    'template name'
+  end
+
   def ks_console(*args)
     'console=ttyS99'
   end


### PR DESCRIPTION
Instead of re-syncing my custom kickstart template with the upstream default every time I upgrade Foreman, I thought it might be better to put all my customisations in a 'custom-snippet' and make this a parameter.