### PR TITLE
Fixes #24753 - Fix bonds and vlans deployment

### DIFF
--- a/provisioning_templates/snippet/kickstart_ifcfg_generic_interface.erb
+++ b/provisioning_templates/snippet/kickstart_ifcfg_generic_interface.erb
@@ -46,6 +46,9 @@ DEFROUTE=<%= primary %>
 <%- end -%>
 <%- if @interface.virtual? && (!@subnet.nil? && (@subnet.has_vlanid? || @interface.vlanid.present?)) -%>
 <%=   "VLAN=yes" %>
+<%-   if @attached_to_bond -%>
+<%=     "NM_CONTROLLED=no" %>
+<%-   end -%>
 <%-   if @interface.identifier.match(/^vlan\d+/) -%>
 <%=     "VLAN_NAME_TYPE=VLAN_PLUS_VID_NO_PAD" %>
 <%=     "PHYSDEV=#{@interface.attached_to}" %>

--- a/provisioning_templates/snippet/kickstart_networking_setup.erb
+++ b/provisioning_templates/snippet/kickstart_networking_setup.erb
@@ -34,7 +34,6 @@ kind: snippet
 <%- end -%>
 
 <%- @host.managed_interfaces.each do |interface| %>
-<%-   next if !interface.managed? || (interface.subnet.nil? && interface.subnet6.nil?) -%>
 <%-   next if bonded_interfaces.include?(interface.identifier) -%>
 
 <%-   interface_identifier = @host.bond_interfaces.map { |i| i.identifier }.include?(interface.attached_to) ? interface.identifier : nil %>
@@ -45,6 +44,7 @@ kind: snippet
                         :subnet => interface.subnet,
                         :subnet6 => interface.subnet6,
                         :bonding_interfaces => bonding_interfaces,
-                        :dhcp => interface.subnet.nil? ? false : interface.subnet.dhcp_boot_mode? }) %>
+                        :dhcp => interface.subnet.nil? ? false : interface.subnet.dhcp_boot_mode?,
+                        :attached_to_bond => interface_identifier.present? }) %>
 <%=   save_to_file('/etc/sysconfig/network-scripts/ifcfg-$sanitized_real', ifcfg) %>
 <%- end %>


### PR DESCRIPTION
This makes sure that vlans come up after
host has been provisioned. If a vlan
is on top of a bond, we have to
make sure it is not conrolled
by NM.