### PR TITLE
Product selection for SLES15

### DIFF
--- a/provisioning_templates/provision/autoyast_sles_default.erb
+++ b/provisioning_templates/provision/autoyast_sles_default.erb
@@ -92,6 +92,19 @@ oses:
     </routing>
 <% end -%>
   </networking>
+<% if os_major >= 15 -%>
+  <ntp-client>
+    <ntp_policy>auto</ntp_policy>
+    <ntp_servers config:type="list">
+      <ntp_server>
+        <address><%= host_param('ntp-server') || '0.opensuse.pool.ntp.org' %></address>
+        <iburst config:type="boolean">false</iburst>
+        <offline config:type="boolean">true</offline>
+      </ntp_server>
+    </ntp_servers>
+    <ntp_sync>15</ntp_sync>
+  </ntp-client>
+<% else -%>
   <ntp-client>
     <configure_dhcp config:type="boolean">false</configure_dhcp>
     <peers config:type="list">
@@ -105,6 +118,7 @@ oses:
     <start_at_boot config:type="boolean">true</start_at_boot>
     <start_in_chroot config:type="boolean">true</start_in_chroot>
   </ntp-client>
+<% end -%>
 <% if ! @dynamic -%>
   <%= @host.diskLayout %>
 <% end -%>
@@ -118,9 +132,18 @@ oses:
     </services>
   </runlevel>
   <software>
+<% if os_major >= 15 -%>
+    <products config:type="list">
+      <product>SLES</product>
+    </products>
+    <patterns config:type="list">
+      <pattern>enhanced_base</pattern>
+    </patterns>
+<% else -%>
     <patterns config:type="list">
       <pattern>Minimal</pattern>
     </patterns>
+<% end -%>
     <packages config:type="list">
       <package>lsb-release</package>
       <package>openssh</package>
@@ -217,9 +240,16 @@ rm /etc/resolv.conf
   </timezone>
   <add-on>
     <add_on_products config:type="list">
+<% if os_major >= 15 -%>
+      <listentry>
+        <media_url><%= host_param('sle-module-basesystem-url') %></media_url>
+        <product_dir>/Module-Basesystem</product_dir>
+        <product>sle-module-basesystem</product>
+      </listentry>
+<% end -%>
 <% if puppet_enabled -%>
 <% if host_param_true?('enable-puppetlabs-pc1-repo') -%>
-    <listentry>
+      <listentry>
         <media_url><![CDATA[http://yum.puppetlabs.com/sles/<%= os_major %>/PC1/<%= @host.architecture %>/]]></media_url>
         <name>puppet</name>
         <product>puppet</product>


### PR DESCRIPTION
    - ntp-client spec changed
    - minimal pattern renamed to enhanced_base
    - product must be specified (like SLES)
    - sle-module-basesystem-url must be specified (link to the mounted Packages iso)

Starting with SLE 15, all products are distributed using one medium. You
need to choose which product to install.

See: https://www.suse.com/documentation/sles-15/singlehtml/book_autoyast/book_autoyast.html#sec.ay_12vs15.product-selection