### PR TITLE
Fixes #25172 - support both FreeIPA and Red Hat IDM in user_data and finish templates

### DIFF
--- a/provisioning_templates/finish/kickstart_default_finish.erb
+++ b/provisioning_templates/finish/kickstart_default_finish.erb
@@ -50,7 +50,7 @@ yum -y install ntpdate
 
 <%= snippet 'redhat_register' %>
 
-<% if host_enc['parameters']['realm'] && @host.realm && @host.realm.realm_type == 'FreeIPA' -%>
+<% if host_enc['parameters']['realm'] && @host.realm && ( @host.realm.realm_type == 'FreeIPA' || @host.realm.realm_type == 'Red Hat Identity Management') -%>
 <%= snippet 'freeipa_register' %>
 <% end -%>
 

--- a/provisioning_templates/finish/kickstart_default_finish.erb
+++ b/provisioning_templates/finish/kickstart_default_finish.erb
@@ -50,7 +50,7 @@ yum -y install ntpdate
 
 <%= snippet 'redhat_register' %>
 
-<% if host_enc['parameters']['realm'] && @host.realm && ( @host.realm.realm_type == 'FreeIPA' || @host.realm.realm_type == 'Red Hat Identity Management') -%>
+<% if host_enc['parameters']['realm'] && @host.realm && (@host.realm.realm_type == 'FreeIPA' || @host.realm.realm_type == 'Red Hat Identity Management') -%>
 <%= snippet 'freeipa_register' %>
 <% end -%>
 

--- a/provisioning_templates/user_data/kickstart_default_user_data.erb
+++ b/provisioning_templates/user_data/kickstart_default_user_data.erb
@@ -42,7 +42,7 @@ yum -y install ntpdate
 
 <%= snippet 'redhat_register' %>
 
-<% if host_enc['parameters']['realm'] && @host.realm && @host.realm.realm_type == 'FreeIPA' || @host.realm.realm_type == 'Red Hat Identity Management') -%>
+<% if host_enc['parameters']['realm'] && @host.realm && (@host.realm.realm_type == 'FreeIPA' || @host.realm.realm_type == 'Red Hat Identity Management') -%>
 <%= snippet 'freeipa_register' %>
 <% end -%>
 

--- a/provisioning_templates/user_data/kickstart_default_user_data.erb
+++ b/provisioning_templates/user_data/kickstart_default_user_data.erb
@@ -42,7 +42,7 @@ yum -y install ntpdate
 
 <%= snippet 'redhat_register' %>
 
-<% if host_enc['parameters']['realm'] && @host.realm && @host.realm.realm_type == 'FreeIPA' -%>
+<% if host_enc['parameters']['realm'] && @host.realm && @host.realm.realm_type == 'FreeIPA' || @host.realm.realm_type == 'Red Hat Identity Management') -%>
 <%= snippet 'freeipa_register' %>
 <% end -%>
 


### PR DESCRIPTION
Similar to https://github.com/theforeman/community-templates/pull/520  The kickstart_default_finish and kickstart_default_user_data templates both assume the value of @host.realm.realm_type will either be FreeIPA or Active Directory, but Satellite only allows the creates of AD or "Red Hat Identity Management" type realms.

This brings these two templates into line with the kickstart_default kickstart file 