### PR TITLE
SLES autoyast: Add support for Puppet 5 upstream repos

### DIFF
--- a/provisioning_templates/provision/autoyast_sles_default.erb
+++ b/provisioning_templates/provision/autoyast_sles_default.erb
@@ -248,9 +248,17 @@ rm /etc/resolv.conf
       </listentry>
 <% end -%>
 <% if puppet_enabled -%>
-<% if host_param_true?('enable-puppetlabs-pc1-repo') -%>
-      <listentry>
-        <media_url><![CDATA[http://yum.puppetlabs.com/sles/<%= os_major %>/PC1/<%= @host.architecture %>/]]></media_url>
+<% if host_param_true?('enable-puppetlabs-pc1-repo') or host_param_true?('enable-puppetlabs-puppet5-repo') -%>
+<%
+  puppet_repo_url_base = 'http://yum.puppetlabs.com'
+  if host_param_true?('enable-puppetlabs-pc1-repo')
+    puppet_repo_url = "#{puppet_repo_url_base}/sles/#{os_major}/PC1/#{@host.architecture}/"
+  elsif host_param_true?('enable-puppetlabs-puppet5-repo')
+    puppet_repo_url = "#{puppet_repo_url_base}/puppet5/sles/#{os_major}/#{@host.architecture}/"
+  end
+%>
+    <listentry>
+        <media_url><![CDATA[<%= puppet_repo_url %>]]></media_url>
         <name>puppet</name>
         <product>puppet</product>
         <product_dir>/</product_dir>


### PR DESCRIPTION
This PR fixes the configuration of Puppet 5 upstream repos for SLE11/12.
So far i could test it successfully with SLE 12.3/Puppet 5 on Foreman 1.19/Katello 3.8