### PR TITLE
Use chrony instead of NTP on latest Fedoras

### DIFF
--- a/provisioning_templates/provision/kickstart_default.erb
+++ b/provisioning_templates/provision/kickstart_default.erb
@@ -26,6 +26,7 @@ This template accepts the following parameters:
 - disable-firewall: boolean (default=false)
 - package_upgrade: boolean (default=true)
 - disable-uek: boolean (default=false)
+- use-ntp: boolean (default depends on OS release)
 %>
 <%
   rhel_compatible = @host.operatingsystem.family == 'Redhat' && @host.operatingsystem.name != 'Fedora'
@@ -41,6 +42,7 @@ This template accepts the following parameters:
   salt_enabled = host_param('salt_master') ? true : false
   chef_enabled = @host.respond_to?(:chef_proxy) && @host.chef_proxy
   section_end = (rhel_compatible && os_major <= 5) ? '' : '%end'
+  use_ntp = host_param_true?('use-ntp') || (is_fedora && os_major < 16) || (rhel_compatible && os_major < 8)
 %>
 <% if (is_fedora && os_major < 29) || (rhel_compatible && os_major < 8) -%>
 install
@@ -87,7 +89,12 @@ authselect --useshadow --passalgo=<%= @host.operatingsystem.password_hash.downca
 <% else -%>
 authconfig --useshadow --passalgo=<%= @host.operatingsystem.password_hash.downcase || 'sha256' %> --kickstart
 <% end -%>
+<% if use_ntp -%>
 timezone --utc <%= host_param('time-zone') || 'UTC' %>
+<% else -%>
+timezone --utc <%= host_param('time-zone') || 'UTC' %> <%= host_param('ntp-server') ? "--ntpservers #{host_param('ntp-server')}" : '' %>
+<% end -%>
+
 <% if rhel_compatible -%>
 services --disabled gpm,sendmail,cups,pcmcia,isdn,rawdevices,hpoj,bluetooth,openibd,avahi-daemon,avahi-dnsconfd,hidd,hplip,pcscd
 <% end -%>
@@ -132,7 +139,11 @@ reboot
 %packages
 yum
 dhclient
+<% if use_ntp -%>
 ntp
+<% else -%>
+chrony
+<% end -%>
 wget
 @Core
 <% if os_major >= 6 -%>
@@ -170,9 +181,12 @@ exec < /dev/tty3 > /dev/tty3
 <%= snippet 'kickstart_networking_setup' %>
 <% end -%>
 
-#update local time
-echo "updating system time"
+echo "Updating system time"
+<% if use_ntp -%>
 /usr/sbin/ntpdate -sub <%= host_param('ntp-server') || '0.fedora.pool.ntp.org' %>
+<% else -%>
+/usr/bin/chronyc makestep
+<% end -%>
 /usr/sbin/hwclock --systohc
 
 <% if proxy_uri -%>


### PR DESCRIPTION
Chrony is actually default [since F16](https://fedoraproject.org/wiki/Features/ChronyDefaultNTP).