### PR TITLE
Fixes #25402 - Update DNF module commands

### DIFF
--- a/job_templates/module_action_-_ansible_default.erb
+++ b/job_templates/module_action_-_ansible_default.erb
@@ -15,7 +15,7 @@ template_inputs:
   description: 'The module action enable, install etc'
   input_type: user
   required: true
-  options: "\nlist\ninfo\nenable\ndisable\ninstall\nupdate\nremove\nprovides\nlock\nunlock\nprofile\nstreams"
+  options: "\nlist\ninfo\nenable\ndisable\ninstall\nupdate\nremove\nprovides\nreset"
 - name: module_spec
   description: The module specification. module:stream/profile
   input_type: user

--- a/job_templates/module_action_-_ssh_default.erb
+++ b/job_templates/module_action_-_ssh_default.erb
@@ -15,7 +15,7 @@ template_inputs:
   description: 'The module action enable, install etc.'
   input_type: user
   required: true
-  options: "\nlist\ninfo\nenable\ndisable\ninstall\nupdate\nremove\nprovides\nlock\nunlock\nprofile\nstreams"
+  options: "\nlist\ninfo\nenable\ndisable\ninstall\nupdate\nremove\nprovides\nreset"
 - name: module_spec
   description: The module specification. module:stream/profile
   input_type: user


### PR DESCRIPTION
DNF 4.0 changes the list of module sub commands.
The following commands are no longer valid
1) Lock
2) Unlock
3) Profiles

Also new commands have gotten added
1) Reset


```
$ dnf module --help
........
                  {remove,provides,list,update,install,reset,disable,enable,info}
                  [module_spec [module_spec ...]]
......
```

This commit tries to address those changes.