### PR TITLE
Add FIPS support

### DIFF
--- a/provisioning_templates/PXEGrub/kickstart_default_pxegrub.erb
+++ b/provisioning_templates/PXEGrub/kickstart_default_pxegrub.erb
@@ -57,6 +57,10 @@ oses:
     options.push('inst.stage2=' + @host.operatingsystem.medium_uri(@host).to_s)
   end
 
+  if @host.operatingsystem.name != 'Fedora' && @host.operatingsystem.major.to_i >= 7 && host_param_true?('fips_enabled')
+    options.push('fips=1')
+  end
+
   ksoptions = options.join(' ')
 -%>
 

--- a/provisioning_templates/PXEGrub2/kickstart_default_pxegrub2.erb
+++ b/provisioning_templates/PXEGrub2/kickstart_default_pxegrub2.erb
@@ -57,6 +57,10 @@ oses:
     options.push('inst.stage2=' + @host.operatingsystem.medium_uri(@host).to_s)
   end
 
+  if @host.operatingsystem.name != 'Fedora' && @host.operatingsystem.major.to_i >= 7 && host_param_true?('fips_enabled')
+    options.push('fips=1')
+  end
+
   # send PXELinux "IPAPPEND 2" option along
   options.push("BOOTIF=01-$net_default_mac")
 

--- a/provisioning_templates/PXELinux/kickstart_default_pxelinux.erb
+++ b/provisioning_templates/PXELinux/kickstart_default_pxelinux.erb
@@ -57,6 +57,10 @@ oses:
     options.push('inst.stage2=' + @host.operatingsystem.medium_uri(@host).to_s)
   end
 
+  if @host.operatingsystem.name != 'Fedora' && @host.operatingsystem.major.to_i >= 7 && host_param_true?('fips_enabled')
+    options.push('fips=1')
+  end
+
   ksoptions = options.join(' ')
   timeout = host_param('loader_timeout').to_i * 10
   timeout = 100 if timeout.nil? || timeout <= 0

--- a/provisioning_templates/iPXE/kickstart_default_ipxe.erb
+++ b/provisioning_templates/iPXE/kickstart_default_ipxe.erb
@@ -18,7 +18,13 @@ oses:
 
 <% stage2 = host_param('kickstart_liveimg') ? 'inst.stage2=' + @host.operatingsystem.medium_uri(@host).to_s : '' %>
 
-kernel <%= "#{@host.url_for_boot(:kernel)}" %> initrd=initrd.img ks=<%= foreman_url('provision')%> inst.stage2=<%= @host.operatingsystem.medium_uri(@host) %> <%= stage2 %> <%= static %> ksdevice=<%= @host.mac %> network kssendmac ks.sendmac inst.ks.sendmac ip=${netX/ip} netmask=${netX/netmask} gateway=${netX/gateway} dns=${dns}
+<%- if @host.operatingsystem.name != 'Fedora' && @host.operatingsystem.major.to_i >= 7 && host_param_true?('fips_enabled') %>
+<%-   fips = 'fips=1' -%>
+<%- else -%>
+<%-   fips = '' -%>
+<%- end -%>
+
+kernel <%= "#{@host.url_for_boot(:kernel)}" %> initrd=initrd.img ks=<%= foreman_url('provision')%> inst.stage2=<%= @host.operatingsystem.medium_uri(@host) %> <%= stage2 %> <%= static %> ksdevice=<%= @host.mac %> network kssendmac ks.sendmac inst.ks.sendmac ip=${netX/ip} netmask=${netX/netmask} gateway=${netX/gateway} dns=${dns} <%= fips %>
 initrd <%= "#{@host.url_for_boot(:initrd)}" %>
 
 boot

--- a/provisioning_templates/provision/kickstart_default.erb
+++ b/provisioning_templates/provision/kickstart_default.erb
@@ -27,6 +27,7 @@ This template accepts the following parameters:
 - package_upgrade: boolean (default=true)
 - disable-uek: boolean (default=false)
 - use-ntp: boolean (default depends on OS release)
+- fips_enabled: boolean (default=false)
 %>
 <%
   rhel_compatible = @host.operatingsystem.family == 'Redhat' && @host.operatingsystem.name != 'Fedora'
@@ -152,6 +153,10 @@ wget
 <% if os_major >= 6 -%>
 redhat-lsb-core
 <% end -%>
+<% if host_param_true?('fips_enabled') -%>
+<%=   snippet 'fips_packages' %>
+<% end -%>
+
 
 <% if salt_enabled %>
 salt-minion

--- a/provisioning_templates/snippet/fips_packages.erb
+++ b/provisioning_templates/snippet/fips_packages.erb
@@ -1,0 +1,8 @@
+<%#
+kind: snippet
+name: fips_packages
+model: ProvisioningTemplate
+snippet: true
+%>
+dracut-fips
+-prelink

--- a/provisioning_templates/snippet/puppet.conf.erb
+++ b/provisioning_templates/snippet/puppet.conf.erb
@@ -40,6 +40,9 @@ vardir = <%= var_dir %>
 logdir = <%= log_dir %>
 rundir = <%= run_dir %>
 ssldir = <%= ssl_dir %>
+<% if host_param_true?('fips_enabled') -%>
+digest_algorithm = sha256
+<% end -%>
 
 [agent]
 pluginsync      = true


### PR DESCRIPTION
This takes custom logic from https://github.com/RedHatSatellite/satellite6-fips-client so we have FIPS support available in upstream templates.

@sideangleside, mind to check whether I missed something? Potentially, @pondrejk would you mind testing?