### PR TITLE
Fixes #26375 - Add flag reboot needed

### DIFF
--- a/job_templates/package_action_-_ssh_default.erb
+++ b/job_templates/package_action_-_ssh_default.erb
@@ -69,6 +69,12 @@ handle_zypp_res_codes () {
 
   if [ "${ZYPP_RES_CODES[$RETVAL]}" != "" ]; then
     echo ${ZYPP_RES_CODES[$RETVAL]}
+
+    # Set flag for later usage in katello tracer upload
+    if [ "$RETVAL" == "102" ]; then
+        touch /var/run/reboot-needed
+    fi
+
     RETVAL=0
   fi
   return $RETVAL


### PR DESCRIPTION
Flag is on tmpfs (= gone after system reboot) which can be used
in katello tracer upload to verify if reboot is required

(see https://github.com/Katello/katello-host-tools/pull/91 for tracer upload zypper plugin)