### PR TITLE
autoyast_default: enable installation of upstream puppet package

### DIFF
--- a/provisioning_templates/provision/autoyast_default.erb
+++ b/provisioning_templates/provision/autoyast_default.erb
@@ -123,13 +123,55 @@ oses:
     <packages config:type="list">
       <package>lsb-release</package>
 <% if puppet_enabled -%>
-      <package>rubygem-puppet</package>
+      <package>puppet-agent</package>
 <% end -%>
 <% if salt_enabled -%>
       <package>salt-minion</package>
 <% end -%>
     </packages>
   </software>
+  <add-on>
+    <add_on_products config:type="list">
+<% if puppet_enabled -%>
+<% if host_param_true?('enable-puppetlabs-pc1-repo') or host_param_true?('enable-puppetlabs-puppet5-repo') -%>
+<%
+  puppet_repo_url_base = 'http://yum.puppetlabs.com'
+  if host_param_true?('enable-puppetlabs-pc1-repo')
+    puppet_repo_url = "#{puppet_repo_url_base}/sles/#{os_major}/PC1/#{@host.architecture}/"
+  elsif host_param_true?('enable-puppetlabs-puppet5-repo')
+    puppet_repo_url = "#{puppet_repo_url_base}/puppet5/sles/#{os_major}/#{@host.architecture}/"
+  end
+%>
+    <listentry>
+        <media_url><![CDATA[<%= puppet_repo_url %>]]></media_url>
+        <name>puppet</name>
+        <product>puppet</product>
+        <product_dir>/</product_dir>
+        <signature-handling>
+          <accept_unknown_gpg_key>
+            <all config:type="boolean">false</all>
+            <keys config:type="list">
+              <keyid>7F438280EF8D349F</keyid>
+            </keys>
+          </accept_unknown_gpg_key>
+          <accept_non_trusted_gpg_key>
+            <all config:type="boolean">false</all>
+            <keys config:type="list">
+              <keyid>7F438280EF8D349F</keyid>
+            </keys>
+          </accept_non_trusted_gpg_key>
+          <import_gpg_key>
+            <all config:type="boolean">false</all>
+            <keys config:type="list">
+              <keyid>7F438280EF8D349F</keyid>
+            </keys>
+          </import_gpg_key>
+        </signature-handling>
+      </listentry>
+<% end -%>
+<% end -%>
+    </add_on_products>
+  </add-on>
   <users config:type="list">
     <user>
       <username>root</username>

--- a/provisioning_templates/provision/autoyast_default.erb
+++ b/provisioning_templates/provision/autoyast_default.erb
@@ -11,6 +11,7 @@ oses:
   pm_set = @host.puppetmaster.empty? ? false : true
   puppet_enabled = pm_set || host_param_true?('force-puppet')
   salt_enabled = host_param('salt_master') ? true : false
+  os_major = @host.operatingsystem.major.to_i
 
   primary_interface_identifier = @host.primary_interface.identifier.blank? ? 'eth0' : @host.primary_interface.identifier
   primary_interface_subnet = @host.primary_interface.subnet
@@ -135,11 +136,12 @@ oses:
 <% if puppet_enabled -%>
 <% if host_param_true?('enable-puppetlabs-pc1-repo') or host_param_true?('enable-puppetlabs-puppet5-repo') -%>
 <%
+  dist_release = os_major == 42 ? '12' : os_major
   puppet_repo_url_base = 'http://yum.puppetlabs.com'
   if host_param_true?('enable-puppetlabs-pc1-repo')
-    puppet_repo_url = "#{puppet_repo_url_base}/sles/#{os_major}/PC1/#{@host.architecture}/"
+    puppet_repo_url = "#{puppet_repo_url_base}/sles/#{dist_release}/PC1/#{@host.architecture}/"
   elsif host_param_true?('enable-puppetlabs-puppet5-repo')
-    puppet_repo_url = "#{puppet_repo_url_base}/puppet5/sles/#{os_major}/#{@host.architecture}/"
+    puppet_repo_url = "#{puppet_repo_url_base}/puppet5/sles/#{dist_release}/#{@host.architecture}/"
   end
 %>
     <listentry>


### PR DESCRIPTION
This commit enables the use of the upstream puppet-agent package on openSUSE Leap. Although Puppet Inc. only packages for SLES, these packages work flawlessly on Leap as well.