### PR TITLE
Fix preseed_default_ipxe with DHCP and no subnet implies DHCP for all Preseed templates

### DIFF
--- a/provisioning_templates/finish/preseed_default_finish.erb
+++ b/provisioning_templates/finish/preseed_default_finish.erb
@@ -15,10 +15,12 @@ oses:
 %>
 
 <% subnet = @host.subnet -%>
-<% if subnet.respond_to?(:dhcp_boot_mode?) -%>
-<% dhcp = subnet.dhcp_boot_mode? && !@static -%>
+<% if @static -%>
+  <%- dhcp = false -%>
+<% elsif subnet.nil? -%>
+  <%- dhcp = true -%>
 <% else -%>
-<% dhcp = !@static -%>
+  <%- dhcp = subnet.respond_to?(:dhcp_boot_mode?) && subnet.dhcp_boot_mode? -%>
 <% end -%>
 <% unless dhcp -%>
 # host and domain name need setting as these values may have come from dhcp if pxe booting

--- a/provisioning_templates/finish/preseed_default_finish.erb
+++ b/provisioning_templates/finish/preseed_default_finish.erb
@@ -20,7 +20,7 @@ oses:
 <% elsif subnet.nil? -%>
   <%- dhcp = true -%>
 <% else -%>
-  <%- dhcp = subnet.respond_to?(:dhcp_boot_mode?) && subnet.dhcp_boot_mode? -%>
+  <%- dhcp = subnet.dhcp_boot_mode? -%>
 <% end -%>
 <% unless dhcp -%>
 # host and domain name need setting as these values may have come from dhcp if pxe booting

--- a/provisioning_templates/iPXE/preseed_default_ipxe.erb
+++ b/provisioning_templates/iPXE/preseed_default_ipxe.erb
@@ -8,16 +8,25 @@ oses:
 - Ubuntu
 %>
 <% if @host.operatingsystem.name == 'Debian' -%>
-<% keyboard_params = "auto=true domain=#{@host.domain}" -%>
+  <%- keyboard_params = "auto=true domain=#{@host.domain}" -%>
 <% else -%>
-<% keyboard_params = 'console-setup/ask_detect=false console-setup/layout=USA console-setup/variant=USA keyboard-configuration/layoutcode=us' -%>
+  <%- keyboard_params = 'console-setup/ask_detect=false console-setup/layout=USA console-setup/variant=USA keyboard-configuration/layoutcode=us' -%>
 <% end -%>
+
+<% subnet = @host.subnet -%>
+<% if subnet.nil? || (subnet.respond_to?(:dhcp_boot_mode?) && subnet.dhcp_boot_mode?) -%>
+  <%- provision_url_suffix = '' -%>
+  <%- netcfg_args = '' -%>
+<% else -%>
+  <%- provision_url_suffix = (@host.token.nil? ? '?' : '&') + 'static=yes' -%>
+  <%- netcfg_args = 'netcfg/disable_dhcp=true netcfg/get_ipaddress=${netX/ip} netcfg/get_netmask=${netX/netmask} netcfg/get_gateway=${netX/gateway} netcfg/get_nameservers=${dns} netcfg/confirm_static=true' -%>
+<% end -%>
+
 <% boot_files_uris = @host.operatingsystem.boot_files_uri(medium_provider) -%>
 <% kernel = boot_files_uris[0] -%>
 <% initrd = boot_files_uris[1] -%>
-<% static = @host.token.nil? ? '?static=yes' : '&static=yes' -%>
 
-kernel <%= kernel %> initrd=initrd.img interface=auto url=<%= foreman_url('provision')%><%= static %> ramdisk_size=10800 root=/dev/rd/0 rw auto netcfg/disable_dhcp=true BOOTIF=01-${netX/mac:hexhyp} hostname=<%= @host.name %> <%= keyboard_params %> locale=<%= host_param('lang') || 'en_US' %> netcfg/get_ipaddress=${netX/ip} netcfg/get_netmask=${netX/netmask} netcfg/get_gateway=${netX/gateway} netcfg/get_nameservers=${dns} netcfg/confirm_static=true
+kernel <%= kernel %> initrd=initrd.img interface=auto url=<%= foreman_url('provision')%><%= provision_url_suffix %> ramdisk_size=10800 root=/dev/rd/0 rw auto BOOTIF=01-${netX/mac:hexhyp} hostname=<%= @host.name %> <%= keyboard_params %> locale=<%= host_param('lang') || 'en_US' %> <%= netcfg_args %>
 initrd <%= initrd %>
 
 boot

--- a/provisioning_templates/iPXE/preseed_default_ipxe.erb
+++ b/provisioning_templates/iPXE/preseed_default_ipxe.erb
@@ -14,7 +14,7 @@ oses:
 <% end -%>
 
 <% subnet = @host.subnet -%>
-<% if subnet.nil? || (subnet.respond_to?(:dhcp_boot_mode?) && subnet.dhcp_boot_mode?) -%>
+<% if subnet.nil? || subnet.dhcp_boot_mode? -%>
   <%- provision_url_suffix = '' -%>
   <%- netcfg_args = '' -%>
 <% else -%>

--- a/provisioning_templates/provision/preseed_default.erb
+++ b/provisioning_templates/provision/preseed_default.erb
@@ -35,7 +35,7 @@ d-i console-keymaps-at/keymap seen true
 <% elsif subnet.nil? -%>
   <%- dhcp = true -%>
 <% else -%>
-  <%- dhcp = subnet.respond_to?(:dhcp_boot_mode?) && subnet.dhcp_boot_mode? -%>
+  <%- dhcp = subnet.dhcp_boot_mode? -%>
 <% end -%>
 <% unless dhcp -%>
 # Static network configuration.

--- a/provisioning_templates/provision/preseed_default.erb
+++ b/provisioning_templates/provision/preseed_default.erb
@@ -30,10 +30,12 @@ d-i console-keymaps-at/keymap seen true
 <% end -%>
 
 <% subnet = @host.subnet -%>
-<% if subnet.respond_to?(:dhcp_boot_mode?) -%>
-  <% dhcp = subnet.dhcp_boot_mode? && !@static -%>
+<% if @static -%>
+  <%- dhcp = false -%>
+<% elsif subnet.nil? -%>
+  <%- dhcp = true -%>
 <% else -%>
-  <% dhcp = !@static -%>
+  <%- dhcp = subnet.respond_to?(:dhcp_boot_mode?) && subnet.dhcp_boot_mode? -%>
 <% end -%>
 <% unless dhcp -%>
 # Static network configuration.

--- a/provisioning_templates/snippet/preseed_networking_setup.erb
+++ b/provisioning_templates/snippet/preseed_networking_setup.erb
@@ -8,9 +8,9 @@ description: this will configure your host networking, it configures your primar
     called in your preseed finish template.
 %>
 <% host_subnet = @host.subnet -%>
-<% host_dhcp = host_subnet.nil? ? false : host_subnet.dhcp_boot_mode? -%>
+<% host_dhcp = host_subnet.nil? ? true : host_subnet.dhcp_boot_mode? -%>
 <% host_subnet6 = @host.subnet6 -%>
-<% host_dhcp6 = host_subnet6.nil? ? false : host_subnet6.dhcp_boot_mode? -%>
+<% host_dhcp6 = host_subnet6.nil? ? true : host_subnet6.dhcp_boot_mode? -%>
 
 real=`ip -o link | awk '/<%= @host.mac -%>/ {print $2;}' | sed s/://`
 cat << EOF > /etc/network/interfaces
@@ -22,7 +22,7 @@ iface lo inet loopback
 auto $real
 allow-hotplug $real
 iface $real inet <%= host_dhcp ? 'dhcp' : 'static' %>
-<% unless host_dhcp -%>
+<% if host_subnet && !host_dhcp -%>
     address <%= @host.ip %>
     gateway <%= host_subnet.gateway %>
     netmask <%= host_subnet.mask %>
@@ -40,9 +40,9 @@ EOF
 
 <% @host.managed_interfaces.each do |interface| -%>
 <% interface_subnet = interface.subnet -%>
-<% interface_dhcp = interface_subnet.nil? ? false : interface_subnet.dhcp_boot_mode? -%>
+<% interface_dhcp = interface_subnet.nil? ? true : interface_subnet.dhcp_boot_mode? -%>
 <% interface_subnet6 = interface.subnet6 -%>
-<% interface_dhcp6 = interface_subnet6.nil? ? false : interface_subnet6.dhcp_boot_mode? -%>
+<% interface_dhcp6 = interface_subnet6.nil? ? true : interface_subnet6.dhcp_boot_mode? -%>
 <% next if !interface.managed? || (interface_subnet.nil? && interface_subnet6.nil?) || interface.primary -%>
 real=`ip -o link | awk '/<%= interface.mac -%>/ {print $2;}' | sed s/:$//`
 <% virtual = interface.virtual? -%>


### PR DESCRIPTION
The preseed_default_ipxe template as it was, was hardcoded to only do static addresses. This allows both static and DHCP.

And across all Preseed templates if the host/interface has no subnet then that implies DHCP addressing.

From this discussion: https://community.theforeman.org/t/foreman-bootdisk-and-external-dhcp/7355/8

Fixes this issue: https://projects.theforeman.org/issues/26448