### PR TITLE
Preseed ignore drives marked 'removable'

### DIFF
--- a/partition_tables_templates/preseed_default.erb
+++ b/partition_tables_templates/preseed_default.erb
@@ -18,11 +18,9 @@ oses:
 d-i partman-auto/disk string <%= host_param('install-disk') %>
 d-i grub-installer/bootdev string <%= host_param('install-disk') %>
 <% else -%>
-# Use the first detected hard disk not detected as removable
+# Use the first detected hard disk
 d-i partman/early_command string \
-  IGNORE_LIST="$(mktemp)"; \
-  dmesg | grep -io "\[[a-z]\+].*removable" | sed -r "s/\[([^]]+).*/\/dev\/\1/" > "$IGNORE_LIST"; \
-  INSTALL_DISK="$(list-devices disk | sort - "$IGNORE_LIST" "$IGNORE_LIST" | uniq -u | head -n1)"; \
+  INSTALL_DISK="$(list-devices disk | head -n1)"; \
   debconf-set partman-auto/disk "$INSTALL_DISK"; \
   debconf-set grub-installer/bootdev "$INSTALL_DISK"
 <% end -%>

--- a/partition_tables_templates/preseed_default.erb
+++ b/partition_tables_templates/preseed_default.erb
@@ -18,9 +18,11 @@ oses:
 d-i partman-auto/disk string <%= host_param('install-disk') %>
 d-i grub-installer/bootdev string <%= host_param('install-disk') %>
 <% else -%>
-# Use the first detected hard disk
+# Use the first detected hard disk not detected as removable
 d-i partman/early_command string \
-  INSTALL_DISK="$(list-devices disk | head -n1)"; \
+  IGNORE_LIST="$(mktemp)"; \
+  dmesg | grep -io "\[[a-z]\+].*removable" | sed -r "s/\[([^]]+).*/\/dev\/\1/" > "$IGNORE_LIST"; \
+  INSTALL_DISK="$(list-devices disk | sort - "$IGNORE_LIST" "$IGNORE_LIST" | uniq -u | head -n1)"; \
   debconf-set partman-auto/disk "$INSTALL_DISK"; \
   debconf-set grub-installer/bootdev "$INSTALL_DISK"
 <% end -%>

--- a/partition_tables_templates/preseed_default.erb
+++ b/partition_tables_templates/preseed_default.erb
@@ -16,9 +16,15 @@ oses:
 
 <% if host_param('install-disk') -%>
 d-i partman-auto/disk string <%= host_param('install-disk') %>
+d-i grub-installer/bootdev string <%= host_param('install-disk') %>
 <% else -%>
-# Use the first detected hard disk as default installation disk
-d-i partman/early_command string debconf-set partman-auto/disk "$(list-devices disk | head -n1)"
+# Use the first detected hard disk not detected as removable
+d-i partman/early_command string \
+  IGNORE_LIST="$(mktemp)"; \
+  dmesg | grep -io "\[[a-z]\+].*removable" | sed -r "s/\[([^]]+).*/\/dev\/\1/" > "$IGNORE_LIST"; \
+  INSTALL_DISK="$(list-devices disk | sort - "$IGNORE_LIST" "$IGNORE_LIST" | uniq -u | head -n1)"; \
+  debconf-set partman-auto/disk "$INSTALL_DISK"; \
+  debconf-set grub-installer/bootdev "$INSTALL_DISK"
 <% end -%>
 
 ### Partitioning

--- a/partition_tables_templates/preseed_default_lvm.erb
+++ b/partition_tables_templates/preseed_default_lvm.erb
@@ -19,9 +19,15 @@ oses:
 
 <% if host_param('install-disk') -%>
 d-i partman-auto/disk string <%= host_param('install-disk') %>
+d-i grub-installer/bootdev string <%= host_param('install-disk') %>
 <% else -%>
-# Use the first detected hard disk as default installation disk
-d-i partman/early_command string debconf-set partman-auto/disk "$(list-devices disk | head -n1)"
+# Use the first detected hard disk not detected as removable
+d-i partman/early_command string \
+  IGNORE_LIST="$(mktemp)"; \
+  dmesg | grep -io "\[[a-z]\+].*removable" | sed -r "s/\[([^]]+).*/\/dev\/\1/" > "$IGNORE_LIST"; \
+  INSTALL_DISK="$(list-devices disk | sort - "$IGNORE_LIST" "$IGNORE_LIST" | uniq -u | head -n1)"; \
+  debconf-set partman-auto/disk "$INSTALL_DISK"; \
+  debconf-set grub-installer/bootdev "$INSTALL_DISK"
 <% end -%>
 
 ### Partitioning

--- a/partition_tables_templates/preseed_default_lvm.erb
+++ b/partition_tables_templates/preseed_default_lvm.erb
@@ -21,11 +21,9 @@ oses:
 d-i partman-auto/disk string <%= host_param('install-disk') %>
 d-i grub-installer/bootdev string <%= host_param('install-disk') %>
 <% else -%>
-# Use the first detected hard disk not detected as removable
+# Use the first detected hard disk
 d-i partman/early_command string \
-  IGNORE_LIST="$(mktemp)"; \
-  dmesg | grep -io "\[[a-z]\+].*removable" | sed -r "s/\[([^]]+).*/\/dev\/\1/" > "$IGNORE_LIST"; \
-  INSTALL_DISK="$(list-devices disk | sort - "$IGNORE_LIST" "$IGNORE_LIST" | uniq -u | head -n1)"; \
+  INSTALL_DISK="$(list-devices disk | head -n1)"; \
   debconf-set partman-auto/disk "$INSTALL_DISK"; \
   debconf-set grub-installer/bootdev "$INSTALL_DISK"
 <% end -%>

--- a/partition_tables_templates/preseed_default_lvm.erb
+++ b/partition_tables_templates/preseed_default_lvm.erb
@@ -21,9 +21,11 @@ oses:
 d-i partman-auto/disk string <%= host_param('install-disk') %>
 d-i grub-installer/bootdev string <%= host_param('install-disk') %>
 <% else -%>
-# Use the first detected hard disk
+# Use the first detected hard disk not detected as removable
 d-i partman/early_command string \
-  INSTALL_DISK="$(list-devices disk | head -n1)"; \
+  IGNORE_LIST="$(mktemp)"; \
+  dmesg | grep -io "\[[a-z]\+].*removable" | sed -r "s/\[([^]]+).*/\/dev\/\1/" > "$IGNORE_LIST"; \
+  INSTALL_DISK="$(list-devices disk | sort - "$IGNORE_LIST" "$IGNORE_LIST" | uniq -u | head -n1)"; \
   debconf-set partman-auto/disk "$INSTALL_DISK"; \
   debconf-set grub-installer/bootdev "$INSTALL_DISK"
 <% end -%>

--- a/provisioning_templates/provision/preseed_default.erb
+++ b/provisioning_templates/provision/preseed_default.erb
@@ -140,11 +140,6 @@ popularity-contest popularity-contest/participate boolean false
 #grub-pc grub-pc/timeout string 10
 d-i grub-installer/only_debian boolean true
 d-i grub-installer/with_other_os boolean true
-<% if host_param('install-disk') -%>
-d-i grub-installer/bootdev string <%= host_param('install-disk') %>
-<% elsif (@host.operatingsystem.name == 'Debian' and @host.operatingsystem.major.to_i >= 8) or (@host.operatingsystem.name == 'Ubuntu' and @host.operatingsystem.major.to_i >= 16) -%>
-d-i grub-installer/bootdev string default
-<% end -%>
 d-i finish-install/reboot_in_progress note
 
 d-i preseed/late_command string wget -Y off <%= @static ? "'#{foreman_url('finish')}&static=true'" : foreman_url('finish') %> -O /target/tmp/finish.sh && in-target chmod +x /tmp/finish.sh && in-target /tmp/finish.sh


### PR DESCRIPTION
Use `dmesg` to find drives marked as removable. This may not be bulletproof or future-proof but if the `dmesg` messages aren't what we are looking for then we are simply in the same situation we were before this PR. 

In my testing of this with Ubuntu 18.04 it correctly ignores both USB sticks and the 'virtual floppy' that Intel AMT creates, both of which the old code of picking the first of `list-devices disk` tried to installed to.

Also makes `grub-installer/bootdev` consistent with `partman-auto/disk`. At the moment (and I have experienced this) GRUB can attempt to be installed on a removable disk using `grub-installer/bootdev string default` and I would think the default should be the boot disk is the same one as the partitioned disk. One niggle I have with this is moving a `grub-installer` command inside the partitioning template which previously was only `partman` commands. But maybe for this setting it makes sense?