### PR TITLE
Fixes #26587 - improve performance of registered hosts report

### DIFF
--- a/report_templates/registered_hosts.erb
+++ b/report_templates/registered_hosts.erb
@@ -13,7 +13,7 @@ require:
 - plugin: katello
 ￼ version: 3.9.0
 -%>
-<%- load_hosts(search: input('Hosts filter'), includes: [:operatingsystem, :subscriptions, :interfaces, :applicable_errata, :applicable_rpms], preload: [:kernel_release, :owner]).each_record do |host| -%>
+<%- load_hosts(search: input('Hosts filter'), includes: [:operatingsystem, :subscriptions, :interfaces, :applicable_errata], preload: [:kernel_release, :owner]).each_record do |host| -%>
 <%-   report_row(
         'Name': host.name,
         'Ip': host.ip,


### PR DESCRIPTION
Problem arises when user filters by hosts using google-like syntax e.g. "dell". Performance is good if they use "name ~ dell" or don't use the filter at all. But this is quite common. It also consumer a lot of memory. Removing the inclusion of applied rpms didn't have significant performance impact on other filtering.
