### PR TITLE
Apply preseed grub-installer/bootdev in partition template

### DIFF
--- a/partition_tables_templates/preseed_default.erb
+++ b/partition_tables_templates/preseed_default.erb
@@ -16,9 +16,13 @@ oses:
 
 <% if host_param('install-disk') -%>
 d-i partman-auto/disk string <%= host_param('install-disk') %>
+d-i grub-installer/bootdev string <%= host_param('install-disk') %>
 <% else -%>
-# Use the first detected hard disk as default installation disk
-d-i partman/early_command string debconf-set partman-auto/disk "$(list-devices disk | head -n1)"
+# Use the first detected hard disk
+d-i partman/early_command string \
+  INSTALL_DISK="$(list-devices disk | head -n1)"; \
+  debconf-set partman-auto/disk "$INSTALL_DISK"; \
+  debconf-set grub-installer/bootdev "$INSTALL_DISK"
 <% end -%>
 
 ### Partitioning

--- a/partition_tables_templates/preseed_default_lvm.erb
+++ b/partition_tables_templates/preseed_default_lvm.erb
@@ -19,9 +19,13 @@ oses:
 
 <% if host_param('install-disk') -%>
 d-i partman-auto/disk string <%= host_param('install-disk') %>
+d-i grub-installer/bootdev string <%= host_param('install-disk') %>
 <% else -%>
-# Use the first detected hard disk as default installation disk
-d-i partman/early_command string debconf-set partman-auto/disk "$(list-devices disk | head -n1)"
+# Use the first detected hard disk
+d-i partman/early_command string \
+  INSTALL_DISK="$(list-devices disk | head -n1)"; \
+  debconf-set partman-auto/disk "$INSTALL_DISK"; \
+  debconf-set grub-installer/bootdev "$INSTALL_DISK"
 <% end -%>
 
 ### Partitioning

--- a/provisioning_templates/provision/preseed_default.erb
+++ b/provisioning_templates/provision/preseed_default.erb
@@ -140,11 +140,6 @@ popularity-contest popularity-contest/participate boolean false
 #grub-pc grub-pc/timeout string 10
 d-i grub-installer/only_debian boolean true
 d-i grub-installer/with_other_os boolean true
-<% if host_param('install-disk') -%>
-d-i grub-installer/bootdev string <%= host_param('install-disk') %>
-<% elsif (@host.operatingsystem.name == 'Debian' and @host.operatingsystem.major.to_i >= 8) or (@host.operatingsystem.name == 'Ubuntu' and @host.operatingsystem.major.to_i >= 16) -%>
-d-i grub-installer/bootdev string default
-<% end -%>
 d-i finish-install/reboot_in_progress note
 
 d-i preseed/late_command string wget -Y off <%= @static ? "'#{foreman_url('finish')}&static=true'" : foreman_url('finish') %> -O /target/tmp/finish.sh && in-target chmod +x /tmp/finish.sh && in-target /tmp/finish.sh


### PR DESCRIPTION
At the moment `partman-auto/disk` and `grub-installer/bootdev` can end up pointing to different drives. This change moves setting `grub-installer/bootdev` into the preseed partition templates so it is consistent with how `partman-auto/disk` is calculated.

A potential issue with this is that users who have existing custom partition templates might now be missing the `d-i grub-installer/bootdev ...` setting (as it's no longer in the default provisioning template). I'm not sure how best to handle that. One possibility is to leave the setting of `d-i grub-installer/bootdev` in the default provision but I'm not sure how preseed will handle it being set again (and through `d-i partman/early_command`) in the partition template.

This was extracted from #575 at the request of @mmoll 