### PR TITLE
Added new CoreOS installation with callhome

### DIFF
--- a/provisioning_templates/PXELinux/coreos_pxelinux.erb
+++ b/provisioning_templates/PXELinux/coreos_pxelinux.erb
@@ -5,8 +5,13 @@ model: ProvisioningTemplate
 oses:
 - CoreOS
 %>
-DEFAULT coreos
+DEFAULT Fedora CoreOS
 
-LABEL coreos
-    KERNEL <%= @kernel %>
-    APPEND initrd=<%= @initrd %> cloud-config-url=<%= foreman_url('provision')%>
+LABEL Fedora CoreOS
+  KERNEL <%= @kernel %>
+APPEND initrd=<%= @initrd %> ip=dhcp rd.neednet=1 img console=tty0 console=ttyS0 coreos.autologin=tty1 coreos.autologin=ttyS0 coreos.inst=yes coreos.inst.install_dev=<%= host_param('install-disk') %> coreos.first_boot=1 coreos.inst.image_url=<%= host_param('image-url') %> coreos.inst.ignition_url=<%= host_param('ignition-url') %> coreos.inst.callhome_url=<%= foreman_url('provision')%>
+  IPAPPEND 2
+
+LABEL CoreOS Legacy
+  KERNEL <%= @kernel %>
+  APPEND initrd=<%= @initrd %> cloud-config-url=<%= foreman_url('provision')%>


### PR DESCRIPTION
This is support for the Fedora CoreOS new installer, parameters has changed and this also supports new "call home" URL which is pending review at: https://github.com/coreos/coreos-installer/pull/25 so hold on merging this.