### PR TITLE
Fix selection of PXELinux menu based on default_pxe_item_global setting

### DIFF
--- a/provisioning_templates/PXELinux/pxelinux_default_local_boot.erb
+++ b/provisioning_templates/PXELinux/pxelinux_default_local_boot.erb
@@ -5,9 +5,10 @@ model: ProvisioningTemplate
 %>
 <%# Used to boot provisioned hosts, do not associate or change the name. %>
 
-DEFAULT menu
+UI menu.c32
 MENU TITLE Booting local disk (ESC to stop)
 TIMEOUT 200
 ONTIMEOUT <%= global_setting("default_pxe_item_local", "local_chain_hd0") %>
+DEFAULT <%= global_setting("default_pxe_item_local", "local_chain_hd0") %>
 
 <%= snippet "pxelinux_chainload" %>

--- a/provisioning_templates/PXELinux/pxelinux_global_default.erb
+++ b/provisioning_templates/PXELinux/pxelinux_global_default.erb
@@ -5,10 +5,11 @@ model: ProvisioningTemplate
 %>
 <%# Used to boot unknown hosts, do not associate or change the name. %>
 
-DEFAULT menu
+UI menu.c32
 MENU TITLE Booting unknown host (ESC to stop)
 TIMEOUT 200
 ONTIMEOUT <%= global_setting("default_pxe_item_global", "local") %>
+DEFAULT <%= global_setting("default_pxe_item_global", "local") %>
 
 <%= snippet "pxelinux_chainload" %>
 

--- a/provisioning_templates/snippet/pxelinux_chainload.erb
+++ b/provisioning_templates/snippet/pxelinux_chainload.erb
@@ -6,7 +6,6 @@ snippet: true
 %>
 LABEL local
   MENU LABEL Default local boot
-  MENU DEFAULT
   LOCALBOOT 0
 
 LABEL local_primary


### PR DESCRIPTION
This should fix the PXELinux menu, where the visually selected entry did not match the entry that booted on timeout (when the 'default_pxe_item_global' setting is altered). 

See also the original topic: [Changing the Default PXE global template entry doesn’t pre-select the proper entry](https://community.theforeman.org/t/community-templates-changing-the-default-pxe-global-template-entry-doesnt-pre-select-the-proper-entry/13922)
And some related documentation, explaining why UI directive is needed for this: https://wiki.syslinux.org/wiki/index.php?title=Menu#DEFAULT

Some questions came up while applying the change:

1. Do we need to remove the "MENU DEFAULT" directive in the following included [pxelinux_chainload](https://github.com/theforeman/community-templates/blob/develop/provisioning_templates/snippet/pxelinux_chainload.erb#L9) snippet? As this makes it redundant.
2. That also makes me wonder if it is intentional that [pxelinux_default_local_boot](https://github.com/theforeman/community-templates/blob/develop/provisioning_templates/PXELinux/pxelinux_default_local_boot.erb#L11) boots immediately, without a timeout. This template also includes the snippet 'pxelinux_chainload'. It looks like that was mistakenly (?) changed by [this commit](https://github.com/theforeman/community-templates/commit/7233b6195fcd92ce0127ed59bab4426e030545f3#diff-730e3efa754c32931e4ce5bc07ffe775).