### PR TITLE
Ansible power action should use shell module

### DIFF
--- a/job_templates/power_action_-_ansible_default.erb
+++ b/job_templates/power_action_-_ansible_default.erb
@@ -18,7 +18,7 @@ model: JobTemplate
 ---
 - hosts: all
   tasks:
-    - command: |
+    - shell: |
         echo <%= input('action') %> host && sleep 3
         <%= case input('action')
           when 'restart'


### PR DESCRIPTION
Tested with the simple Ansible playbook
~~~
- hosts: rhel8.acme.lab
  tasks:
    - command: |
        echo restart host && sleep 3
        shutdown -r +1
~~~

~~~
ansible-playbook -i /tmp/host reboot.yaml --ask-pass -e 'ansible_python_interpreter=/usr/libexec/platform-python'
SSH password: 

PLAY [rhel8.acme.lab] ******************************************************************************************************************************************************

TASK [Gathering Facts] *****************************************************************************************************************************************************
ok: [rhel8.acme.lab]

TASK [command] *************************************************************************************************************************************************************
changed: [rhel8.acme.lab]

PLAY RECAP *****************************************************************************************************************************************************************
rhel8.acme.lab             : ok=2    changed=1    unreachable=0    failed=0   
~~~

From `/var/log/messages` on the client system

~~~
Jun 26 01:36:36 rhel8 ansible-command[1592]: Invoked with _raw_params=echo restart host && sleep 3#012 shutdown -r +1 warn=True _uses_shell=False argv=None chdir=None executable=None creates=None removes=None stdin=None
~~~

Host didn't reboot, but the job was successful.

After changing the `command` module to `shell` and re-ran the job, following was captured in `/var/log/messages`

~~~
Jun 26 01:58:05 rhel8 ansible-command[1496]: Invoked with _uses_shell=True _raw_params=echo restart host && sleep 3#012 shutdown -r +1 warn=True argv=None chdir=None executable=None creates=None removes=None stdin=None
~~~

And host rebooted successfully after a minute.