### PR TITLE
Refs #27007 - Fix passing command to shell module

### DIFF
--- a/job_templates/run_command_-_ansible_default.erb
+++ b/job_templates/run_command_-_ansible_default.erb
@@ -17,7 +17,8 @@ model: JobTemplate
 ---
 - hosts: all
   tasks:
-    - shell: |
-<%=     indent(8) { input('command') } %>
+    - shell:
+        cmd: |
+<%=       indent(10) { input('command') } %>
       register: out
     - debug: var=out


### PR DESCRIPTION
Ansible < 2.8.0 parses the command in a weird way and adds a
single space at the beginning of each line. This breaks scripts
which contain heredocs.

community-templates variant of https://github.com/theforeman/foreman_ansible/pull/275