### PR TITLE
Adds redhat register snippet to cloud init template

### DIFF
--- a/provisioning_templates/cloud_init/cloud_init_default.erb
+++ b/provisioning_templates/cloud_init/cloud_init_default.erb
@@ -27,6 +27,7 @@ users: {}
 <% if puppet_enabled %>
 runcmd:
 - |
+<%= snippet 'redhat_register' %>
 <% if host_param_true?('enable-puppetlabs-pc1-repo') || host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-puppetlabs-puppet5-repo') -%>
 <%= snippet 'puppetlabs_repo' %>
 <% end -%>


### PR DESCRIPTION
Cloud init template was missing the redhat register snippet. 
So, boxes provisioned were not subscribed to the foreman. This helps make the cloud init template closer to the Kickstart default user data template
Preview of the template after snippet is added.
```
runcmd:
- |
  echo ##############################################################
  echo ################# SUBSCRIPTION MANAGER #######################
  echo ##############################################################
  echo
  echo "Starting the subscription-manager registration process"

    if [ -f /usr/bin/dnf ]; then
      dnf -y install subscription-manager
    else
      yum -t -y install subscription-manager
    fi

    rpm -Uvh http://foreman/pub/katello-ca-consumer-latest.noarch.rpm

    subscription-manager register --name="host.local" --org='Default_Organization' --activationkey='ak-rhel-7'

       if [ -f /usr/bin/dnf ]; then
         PACKAGE_MAN="dnf -y"
       else
         PACKAGE_MAN="yum -t -y"
       fi
      $PACKAGE_MAN install katello-agent
```