### PR TITLE
Fixes #27180 Provisioning host using vlan tagged network

### DIFF
--- a/provisioning_templates/PXELinux/kickstart_default_pxelinux.erb
+++ b/provisioning_templates/PXELinux/kickstart_default_pxelinux.erb
@@ -38,12 +38,12 @@ oses:
       # old Anacoda found in Fedora 16 or RHEL 6 and older
       dns_servers = subnet.dns_servers.join(',')
       options.push("ip=#{ip}", "netmask=#{mask}", "gateway=#{gw}", "dns=#{dns_servers}")
-      if iface.tag.present? &&  iface.attached_to.present?
+      if iface.tag.present? && iface.attached_to.present?
         options.push("vlanid=#{iface.tag} ksdevice=#{iface.identifier} rd.bootif=0")
       end
     else
       options.push("ip=#{ip}::#{gw}:#{mask}:#{hostname}:#{iface.identifier}:none")
-      if iface.tag.present? &&  iface.attached_to.present?
+      if iface.tag.present? && iface.attached_to.present?
         options.push("vlan=#{iface.identifier}:#{iface.attached_to} bootdev=#{iface.identifier} ifname=#{iface.attached_to}:#{mac} rd.bootif=0")
       end
       subnet.dns_servers.each { |server|

--- a/provisioning_templates/PXELinux/kickstart_default_pxelinux.erb
+++ b/provisioning_templates/PXELinux/kickstart_default_pxelinux.erb
@@ -32,12 +32,20 @@ oses:
     ip = @host.provision_interface.ip
     mask = subnet.mask
     gw = subnet.gateway
+    hostname = @host.name
+    interface = @host.provision_interface.identifier
     if (@host.operatingsystem.name.match(/Fedora/i) && major < 17) || major < 7
       # old Anacoda found in Fedora 16 or RHEL 6 and older
       dns_servers = subnet.dns_servers.join(',')
       options.push("ip=#{ip}", "netmask=#{mask}", "gateway=#{gw}", "dns=#{dns_servers}")
+      if @host.provision_interface.tag.present? &&  @host.provision_interface.attached_to.present?
+        options.push("vlanid=#{@host.provision_interface.tag} ksdevice=#{@host.provision_interface.identifier} rd.bootif=0")
+      end
     else
-      options.push("ip=#{ip}::#{gw}:#{mask}:::none")
+      options.push("ip=#{ip}::#{gw}:#{mask}:#{hostname}:#{interface}:none")
+      if @host.provision_interface.tag.present? &&  @host.provision_interface.attached_to.present?
+        options.push("vlan=#{interface}:#{@host.provision_interface.attached_to} bootdev=#{interface} ifname=#{@host.provision_interface.attached_to}:#{mac} rd.bootif=0")
+      end
       subnet.dns_servers.each { |server|
         options.push("nameserver=#{server}")
       }

--- a/provisioning_templates/PXELinux/kickstart_default_pxelinux.erb
+++ b/provisioning_templates/PXELinux/kickstart_default_pxelinux.erb
@@ -33,18 +33,18 @@ oses:
     mask = subnet.mask
     gw = subnet.gateway
     hostname = @host.name
-    interface = @host.provision_interface.identifier
+    iface = @host.provision_interface
     if (@host.operatingsystem.name.match(/Fedora/i) && major < 17) || major < 7
       # old Anacoda found in Fedora 16 or RHEL 6 and older
       dns_servers = subnet.dns_servers.join(',')
       options.push("ip=#{ip}", "netmask=#{mask}", "gateway=#{gw}", "dns=#{dns_servers}")
-      if @host.provision_interface.tag.present? &&  @host.provision_interface.attached_to.present?
-        options.push("vlanid=#{@host.provision_interface.tag} ksdevice=#{@host.provision_interface.identifier} rd.bootif=0")
+      if iface.tag.present? &&  iface.attached_to.present?
+        options.push("vlanid=#{iface.tag} ksdevice=#{iface.identifier} rd.bootif=0")
       end
     else
-      options.push("ip=#{ip}::#{gw}:#{mask}:#{hostname}:#{interface}:none")
-      if @host.provision_interface.tag.present? &&  @host.provision_interface.attached_to.present?
-        options.push("vlan=#{interface}:#{@host.provision_interface.attached_to} bootdev=#{interface} ifname=#{@host.provision_interface.attached_to}:#{mac} rd.bootif=0")
+      options.push("ip=#{ip}::#{gw}:#{mask}:#{hostname}:#{iface.identifier}:none")
+      if iface.tag.present? &&  iface.attached_to.present?
+        options.push("vlan=#{iface.identifier}:#{iface.attached_to} bootdev=#{iface.identifier} ifname=#{iface.attached_to}:#{mac} rd.bootif=0")
       end
       subnet.dns_servers.each { |server|
         options.push("nameserver=#{server}")

--- a/provisioning_templates/iPXE/kickstart_default_ipxe.erb
+++ b/provisioning_templates/iPXE/kickstart_default_ipxe.erb
@@ -16,13 +16,26 @@ oses:
   <% static = (@host.token.nil? ? '?' : '&') + static_arg -%>
 <% end -%>
 
+<%
+options = []
+hostname = @host.name
+interface = @host.provision_interface.identifier
+mac = @host.provision_interface.mac
+-%>
+
 <% stage2 = host_param('kickstart_liveimg') ? 'inst.stage2=' + @host.operatingsystem.medium_uri(@host).to_s : '' %>
 
-<%- if (@host.operatingsystem.name.match(/Fedora/i) && @host.operatingsystem.major.to_i < 17) || @host.operatingsystem.major.to_i < 7 %>
-<%- net_options = 'ip=${netX/ip} netmask=${netX/netmask} gateway=${netX/gateway} dns=${dns}' -%>
-<%- else -%>
-<%- net_options = 'ip=${netX/ip}::${netX/gateway}:${netX/netmask}:::none nameserver=${dns}' -%>
-<%- end -%>
+<%- if (@host.operatingsystem.name.match(/Fedora/i) && @host.operatingsystem.major.to_i < 17) || @host.operatingsystem.major.to_i < 7
+      options.push('ip=${netX/ip} netmask=${netX/netmask} gateway=${netX/gateway} dns=${dns}')
+      if @host.provision_interface.tag.present? &&  @host.provision_interface.attached_to.present?
+        options.push("vlanid=#{@host.provision_interface.tag} ksdevice=#{@host.provision_interface.identifier}")
+      end
+else
+  options.push("ip=${netX/ip}::${netX/gateway}:${netX/netmask}:#{hostname}:#{interface}:none nameserver=${dns}")
+  if @host.provision_interface.tag.present? &&  @host.provision_interface.attached_to.present?
+    options.push("vlan=#{interface}:#{@host.provision_interface.attached_to} bootdev=#{interface} ifname=#{@host.provision_interface.attached_to}:#{mac}")
+  end
+  end -%>
 
 <%- if @host.operatingsystem.name != 'Fedora' && @host.operatingsystem.major.to_i >= 7 && host_param_true?('fips_enabled') %>
 <%-   fips = 'fips=1' -%>

--- a/provisioning_templates/iPXE/kickstart_default_ipxe.erb
+++ b/provisioning_templates/iPXE/kickstart_default_ipxe.erb
@@ -19,7 +19,7 @@ oses:
 <%
 options = []
 hostname = @host.name
-interface = @host.provision_interface.identifier
+iface = @host.provision_interface
 mac = @host.provision_interface.mac
 -%>
 
@@ -27,15 +27,17 @@ mac = @host.provision_interface.mac
 
 <%- if (@host.operatingsystem.name.match(/Fedora/i) && @host.operatingsystem.major.to_i < 17) || @host.operatingsystem.major.to_i < 7
       options.push('ip=${netX/ip} netmask=${netX/netmask} gateway=${netX/gateway} dns=${dns}')
-      if @host.provision_interface.tag.present? &&  @host.provision_interface.attached_to.present?
-        options.push("vlanid=#{@host.provision_interface.tag} ksdevice=#{@host.provision_interface.identifier}")
+      if iface.tag.present? &&  iface.attached_to.present?
+        options.push("vlanid=#{iface.tag} ksdevice=#{iface.identifier}")
       end
-else
-  options.push("ip=${netX/ip}::${netX/gateway}:${netX/netmask}:#{hostname}:#{interface}:none nameserver=${dns}")
-  if @host.provision_interface.tag.present? &&  @host.provision_interface.attached_to.present?
-    options.push("vlan=#{interface}:#{@host.provision_interface.attached_to} bootdev=#{interface} ifname=#{@host.provision_interface.attached_to}:#{mac}")
-  end
-  end -%>
+    else
+        options.push("ip=${netX/ip}::${netX/gateway}:${netX/netmask}:#{hostname}:#{interface}:none nameserver=${dns}")
+        if iface.tag.present? &&  iface.attached_to.present?
+          options.push("vlan=#{iface.identifier}:#{iface.attached_to} bootdev=#{iface.identifier} ifname=#{iface.attached_to}:#{mac}")
+        end
+    end -%>
+
+<% ksoptions = options.join(' ')-%>
 
 <%- if @host.operatingsystem.name != 'Fedora' && @host.operatingsystem.major.to_i >= 7 && host_param_true?('fips_enabled') %>
 <%-   fips = 'fips=1' -%>
@@ -43,7 +45,7 @@ else
 <%-   fips = '' -%>
 <%- end -%>
 
-kernel <%= "#{@host.url_for_boot(:kernel)}" %> initrd=initrd.img ks=<%= foreman_url('provision')%><%= static %> inst.stage2=<%= @host.operatingsystem.medium_uri(@host) %> <%= stage2 %> ksdevice=<%= @host.mac %> network kssendmac ks.sendmac inst.ks.sendmac <%= net_options %> <%= fips %>
+kernel <%= "#{@host.url_for_boot(:kernel)}" %> initrd=initrd.img ks=<%= foreman_url('provision')%><%= static %> inst.stage2=<%= @host.operatingsystem.medium_uri(@host) %> <%= stage2 %> ksdevice=<%= @host.mac %> network kssendmac ks.sendmac inst.ks.sendmac <%= ksoptions %> <%= fips %>
 initrd <%= "#{@host.url_for_boot(:initrd)}" %>
 imgstat
 sleep 2

--- a/provisioning_templates/iPXE/kickstart_default_ipxe.erb
+++ b/provisioning_templates/iPXE/kickstart_default_ipxe.erb
@@ -25,19 +25,21 @@ mac = @host.provision_interface.mac
 
 <% stage2 = host_param('kickstart_liveimg') ? 'inst.stage2=' + @host.operatingsystem.medium_uri(@host).to_s : '' %>
 
-<%- if (@host.operatingsystem.name.match(/Fedora/i) && @host.operatingsystem.major.to_i < 17) || @host.operatingsystem.major.to_i < 7
-      options.push('ip=${netX/ip} netmask=${netX/netmask} gateway=${netX/gateway} dns=${dns}')
-      if iface.tag.present? &&  iface.attached_to.present?
-        options.push("vlanid=#{iface.tag} ksdevice=#{iface.identifier}")
-      end
-    else
-        options.push("ip=${netX/ip}::${netX/gateway}:${netX/netmask}:#{hostname}:#{interface}:none nameserver=${dns}")
-        if iface.tag.present? &&  iface.attached_to.present?
-          options.push("vlan=#{iface.identifier}:#{iface.attached_to} bootdev=#{iface.identifier} ifname=#{iface.attached_to}:#{mac}")
-        end
-    end -%>
+<%
+  if (@host.operatingsystem.name.match(/Fedora/i) && @host.operatingsystem.major.to_i < 17) || @host.operatingsystem.major.to_i < 7
+    options.push('ip=${netX/ip} netmask=${netX/netmask} gateway=${netX/gateway} dns=${dns}')
+    if iface.tag.present? && iface.attached_to.present?
+      options.push("vlanid=#{iface.tag} ksdevice=#{iface.identifier}")
+    end
+  else
+    options.push("ip=${netX/ip}::${netX/gateway}:${netX/netmask}:#{hostname}:#{interface}:none nameserver=${dns}")
+    if iface.tag.present? && iface.attached_to.present?
+      options.push("vlan=#{iface.identifier}:#{iface.attached_to} bootdev=#{iface.identifier} ifname=#{iface.attached_to}:#{mac}")
+    end
+  end
+-%>
 
-<% ksoptions = options.join(' ')-%>
+<% ksoptions = options.join(' ') -%>
 
 <%- if @host.operatingsystem.name != 'Fedora' && @host.operatingsystem.major.to_i >= 7 && host_param_true?('fips_enabled') %>
 <%-   fips = 'fips=1' -%>

--- a/provisioning_templates/provision/kickstart_default.erb
+++ b/provisioning_templates/provision/kickstart_default.erb
@@ -43,7 +43,15 @@ This template accepts the following parameters:
   chef_enabled = @host.respond_to?(:chef_proxy) && @host.chef_proxy
   section_end = (rhel_compatible && os_major <= 5) ? '' : '%end'
   use_ntp = host_param_true?('use-ntp') || (is_fedora && os_major < 16) || (rhel_compatible && os_major <= 7)
+  iface = @host.provision_interface
 %>
+
+<%- if iface.tag.present? &&  iface.attached_to.present?
+  boot_options = "--device=#{iface.attached_to} --vlanid=#{iface.tag}"
+else
+  boot_options = os_major >= 6 ? " --device=#{@host.mac}" : ''
+end -%>
+
 <% if (is_fedora && os_major < 29) || (rhel_compatible && os_major <= 7) -%>
 install
 <% end -%>
@@ -79,7 +87,7 @@ skipx
 <% dhcp = !@static -%>
 <% end -%>
 
-network --bootproto <%= dhcp ? 'dhcp' : "static --ip=#{@host.ip} --netmask=#{subnet.mask} --gateway=#{subnet.gateway} --nameserver=#{subnet.dns_servers.join(',')} --mtu=#{subnet.mtu.to_s}" %> --hostname <%= @host %><%= os_major >= 6 ? " --device=#{@host.provision_interface.attached_to}" : '' -%> <%= (@host.provision_interface.tag.present? && @host.provision_interface.attached_to.present?) ? "--vlanid=#{@host.provision_interface.tag}" : '' %>
+network --bootproto <%= dhcp ? 'dhcp' : "static --ip=#{@host.ip} --netmask=#{subnet.mask} --gateway=#{subnet.gateway} --nameserver=#{subnet.dns_servers.join(',')} --mtu=#{subnet.mtu.to_s}" %> --hostname <%= @host %> <%= boot_options %>
 
 rootpw --iscrypted <%= root_pass %>
 <% if host_param_true?('disable-firewall') -%>

--- a/provisioning_templates/provision/kickstart_default.erb
+++ b/provisioning_templates/provision/kickstart_default.erb
@@ -80,7 +80,7 @@ skipx
 <% dhcp = !@static -%>
 <% end -%>
 
-network --bootproto <%= dhcp ? 'dhcp' : "static --ip=#{@host.ip} --netmask=#{subnet.mask} --gateway=#{subnet.gateway} --nameserver=#{subnet.dns_servers.join(',')} --mtu=#{subnet.mtu.to_s}" %> --hostname <%= @host %><%= os_major >= 6 ? " --device=#{@host.mac}" : '' -%>
+network --bootproto <%= dhcp ? 'dhcp' : "static --ip=#{@host.ip} --netmask=#{subnet.mask} --gateway=#{subnet.gateway} --nameserver=#{subnet.dns_servers.join(',')} --mtu=#{subnet.mtu.to_s}" %> --hostname <%= @host %><%= os_major >= 6 ? " --device=#{@host.provision_interface.attached_to}" : '' -%> <%= (@host.provision_interface.tag.present? && @host.provision_interface.attached_to.present?) ? "--vlanid=#{@host.provision_interface.tag}" : '' %>
 
 rootpw --iscrypted <%= root_pass %>
 <% if host_param_true?('disable-firewall') -%>

--- a/provisioning_templates/provision/kickstart_default.erb
+++ b/provisioning_templates/provision/kickstart_default.erb
@@ -44,12 +44,13 @@ This template accepts the following parameters:
   section_end = (rhel_compatible && os_major <= 5) ? '' : '%end'
   use_ntp = host_param_true?('use-ntp') || (is_fedora && os_major < 16) || (rhel_compatible && os_major <= 7)
   iface = @host.provision_interface
+  network_options = []
 %>
 
-<%- if iface.tag.present? &&  iface.attached_to.present?
-  boot_options = "--device=#{iface.attached_to} --vlanid=#{iface.tag}"
+<%- if iface.tag.present? && iface.attached_to.present?
+  network_options.push = "--device=#{iface.attached_to} --vlanid=#{iface.tag}"
 else
-  boot_options = os_major >= 6 ? " --device=#{@host.mac}" : ''
+  network_options.push = os_major >= 6 ? " --device=#{@host.mac}" : ''
 end -%>
 
 <% if (is_fedora && os_major < 29) || (rhel_compatible && os_major <= 7) -%>
@@ -87,7 +88,7 @@ skipx
 <% dhcp = !@static -%>
 <% end -%>
 
-network --bootproto <%= dhcp ? 'dhcp' : "static --ip=#{@host.ip} --netmask=#{subnet.mask} --gateway=#{subnet.gateway} --nameserver=#{subnet.dns_servers.join(',')} --mtu=#{subnet.mtu.to_s}" %> --hostname <%= @host %> <%= boot_options %>
+network --bootproto <%= dhcp ? 'dhcp' : "static --ip=#{@host.ip} --netmask=#{subnet.mask} --gateway=#{subnet.gateway} --nameserver=#{subnet.dns_servers.join(',')} --mtu=#{subnet.mtu.to_s}" %> --hostname <%= @host %> <%= network_options.join(' ') %>
 
 rootpw --iscrypted <%= root_pass %>
 <% if host_param_true?('disable-firewall') -%>


### PR DESCRIPTION
Using this modification we will be able to provision the host using VLAN tagged interface using both Host based ISO and Full Host Iso.

