### PR TITLE
Fix - debian package/repo name for puppet6

### DIFF
--- a/provisioning_templates/snippet/puppetlabs_repo.erb
+++ b/provisioning_templates/snippet/puppetlabs_repo.erb
@@ -36,7 +36,7 @@ if host_param_true?('enable-puppetlabs-repo')
   repo_name = 'puppetlabs-release'
   repo_subdir = ''
 elsif host_param_true?('enable-puppetlabs-puppet6-repo')
-  repo_name = 'puppetlabs-release-puppet6'
+  repo_name = 'puppet6-release'
   repo_subdir = 'puppet6/'
 elsif host_param_true?('enable-puppetlabs-puppet5-repo')
   repo_name = 'puppet5-release'


### PR DESCRIPTION
Scheme for puppetlabs-platform:

https://apt.puppet.com/<PLATFORM_VERSION>-release-<VERSION CODE NAME>.deb

e.g. for buster
https://apt.puppet.com/puppet6-release-stretch.deb