### PR TITLE
Fix - Added wget as additional package in preseed template

### DIFF
--- a/provisioning_templates/provision/preseed_default.erb
+++ b/provisioning_templates/provision/preseed_default.erb
@@ -13,7 +13,7 @@ oses:
   os_major = @host.operatingsystem.major.to_i
   squeeze_or_older = (@host.operatingsystem.name == 'Debian' && os_major <= 6)
 
-  additional_packages = ['lsb-release']
+  additional_packages = ['lsb-release','wget']
   additional_packages << host_param('additional-packages')
   additional_packages << 'python' if ansible_enabled
   additional_packages << 'salt-minion' if salt_enabled


### PR DESCRIPTION
As of debian 10 wget it is no longer installed by default but needed e.g. in the preseed last_command.

Although this could be mitigated my adding it to "additional_packages" parameter i consider this to be bug.