### PR TITLE
Do not rush opening iPXE menu

### DIFF
--- a/provisioning_templates/iPXE/ipxe_global_default.erb
+++ b/provisioning_templates/iPXE/ipxe_global_default.erb
@@ -6,6 +6,9 @@ snippet: false
 -%>
 #!ipxe
 
+echo Opening global default menu in 15 seconds...
+sleep 15
+
 set menu-default <%= global_setting("default_pxe_item_global", "local") %>
 set menu-timeout 5000
 set port 8448


### PR DESCRIPTION
When there is some error, the iPXE menu quickly clears the screen. This delays it a bit so you can investigate what was wrong before the default menu pops in.