### PR TITLE
Refs #27109 - specify mandatory key type

### DIFF
--- a/provisioning_templates/snippet/freeipa_register.erb
+++ b/provisioning_templates/snippet/freeipa_register.erb
@@ -39,7 +39,7 @@ snippet: true
   <% if os_major == 7 -%>
     /usr/sbin/sshd-keygen
   <% elsif os_major > 7 %>
-    /usr/libexec/openssh/sshd-keygen
+    /usr/libexec/openssh/sshd-keygen rsa
   <% end -%>
 <% else -%>
   freeipa_client=freeipa-client


### PR DESCRIPTION
@lzap, could you please take a look? This is a follow up of https://github.com/theforeman/community-templates/pull/590, turned out the key type needs to be specified as per https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/installing_identity_management/installing-an-ipa-client-with-kickstart_installing-identity-management#kickstart-file-for-client-installation

The reporter tested this already.