### PR TITLE
Add space after --enable of subscription_manager_repos

### DIFF
--- a/provisioning_templates/snippet/redhat_register.erb
+++ b/provisioning_templates/snippet/redhat_register.erb
@@ -37,7 +37,8 @@ snippet: true
 #   subscription_manager_org = <org name>       Organization name, if required
 #
 #   subscription_manager_repos = <repos>        Additional repositories to enable
-#                                               after registration
+#                                               after registration.
+#                                               Seperate multiple repositories with commas.
 #
 #   subscription_manager_override_repos_cost = <cost>  Override repository cost
 #
@@ -178,7 +179,7 @@ snippet: true
   <% if host_param('subscription_manager_repos') %>
     # workaround for RHEL 6.4 bug https://bugzilla.redhat.com/show_bug.cgi?id=1008016
     subscription-manager repos --list > /dev/null
-    <%= "subscription-manager repos --enable #{host_param('subscription_manager_repos').gsub(',', ' --enable')}" %>
+    <%= "subscription-manager repos --enable #{host_param('subscription_manager_repos').gsub(/,\s*/, ' --enable ')}" %>
   <% end %>
 
   <% if host_param('subscription_manager_override_repos_cost') %>


### PR DESCRIPTION
If multiple repositories are specified with `subscription_manager_repos` and no space is included after the comma, the command will be rendered incorrectly.
Example: By setting `rhel-7-server-rpms,rhel-7-server-optional-rpms`, the following command is rendered:
```
subscription-manager repos --enable rhel-7-server-rpms --enablerhel-7-server-optional-rpms
```

By adding the space, it works again for both variants. Seems like this changed in 6a7e738039965df8245c84c65a8a15b55b9ee89d