### PR TITLE
Fixes simplified grub2 MAC loading

### DIFF
--- a/provisioning_templates/snippet/pxegrub2_mac.erb
+++ b/provisioning_templates/snippet/pxegrub2_mac.erb
@@ -4,9 +4,17 @@ name: pxegrub2_mac
 model: ProvisioningTemplate
 snippet: true
 -%>
-echo "Trying grub.cfg-$net_default_mac"
-source "grub.cfg-$net_default_mac"
-echo "Trying grub2/grub.cfg-$net_default_mac"
-source "grub2/grub.cfg-$net_default_mac"
+echo "Trying /httpboot/grub2/grub.cfg-$net_default_mac"
+configfile "/httpboot/grub2/grub.cfg-$net_default_mac"
+
 echo "Trying /grub2/grub.cfg-$net_default_mac"
-source "/grub2/grub.cfg-$net_default_mac"
+configfile "/grub2/grub.cfg-$net_default_mac"
+
+# Relative paths must go after absolute paths because
+# Grub2 in UEFI HTTP messes URL otherwise and won't load
+# the MAC-based menu.
+echo "Trying grub2/grub.cfg-$net_default_mac"
+configfile "grub2/grub.cfg-$net_default_mac"
+
+echo "Trying grub.cfg-$net_default_mac"
+configfile "grub.cfg-$net_default_mac"


### PR DESCRIPTION
The simplified MAC loading works great:

https://github.com/theforeman/community-templates/pull/606

However, it does not when using grub2 in HTTP UEFI Boot. In that context, grub2 messes URL in memory and then fails to load any file. I have found out that when absolute paths are first, it works fine and only relative paths causes the bug to appear.

Also, instead of "source" we can now use "configfile" statement which prevents from "chainload" items below which can interfere with the included item.