### PR TITLE
Update to Grub2 HTTP UEFI global template

### DIFF
--- a/provisioning_templates/snippet/pxegrub2_discovery.erb
+++ b/provisioning_templates/snippet/pxegrub2_discovery.erb
@@ -15,9 +15,15 @@ Another bug in RHEL 7.4 is affecting $net_default_mac with a trailing slash, in
 the global template we have a regexp module creating corrected variable $mac
 which is used here. See RHBZ#1487107 for more info.
 -%>
-<% ["efi", ""].each do |suffix| %>
-menuentry 'Foreman Discovery Image <%= suffix %>' --id discovery<%= suffix %> {
-  linux<%= suffix %> boot/fdi-image/vmlinuz0 rootflags=loop root=live:/fdi.iso rootfstype=auto ro rd.live.image acpi=force rd.luks=0 rd.md=0 rd.dm=0 rd.lvm=0 rd.bootif=0 rd.neednet=0 nokaslr nomodeset proxy.url=<%= foreman_server_url %> proxy.type=foreman BOOTIF=01-$mac
-  initrd<%= suffix %> boot/fdi-image/initrd0.img
+<%
+  ["efi", ""].each do |suffix|
+    ["/httpboot/", ""].each do |prefix|
+%>
+menuentry 'Foreman Discovery Image <%= prefix.tr('/','') %> <%= suffix %>' --id discovery<%= suffix %><%= prefix.tr('/','') %> {
+  linux<%= suffix %> <%= prefix %>boot/fdi-image/vmlinuz0 rootflags=loop root=live:/fdi.iso rootfstype=auto ro rd.live.image acpi=force rd.luks=0 rd.md=0 rd.dm=0 rd.lvm=0 rd.bootif=0 rd.neednet=0 nokaslr nomodeset proxy.url=<%= foreman_server_url %> proxy.type=foreman BOOTIF=01-$mac
+  initrd<%= suffix %> <%= prefix %>boot/fdi-image/initrd0.img
 }
-<% end %>
+<%
+    end
+  end
+%>

--- a/provisioning_templates/snippet/pxegrub2_mac.erb
+++ b/provisioning_templates/snippet/pxegrub2_mac.erb
@@ -10,9 +10,10 @@ configfile "/httpboot/grub2/grub.cfg-$net_default_mac"
 echo "Trying /grub2/grub.cfg-$net_default_mac"
 configfile "/grub2/grub.cfg-$net_default_mac"
 
-# Relative paths must go after absolute paths because
-# Grub2 in UEFI HTTP messes URL otherwise and won't load
-# the MAC-based menu.
+# The following four statements breaks grub2 and it's no
+# longer able to load any file from the base URL.
+# Comment them out to be able to use (UEFI/iPXE) HTTP Boot:
+# https://bugzilla.redhat.com/show_bug.cgi?id=1763216
 echo "Trying grub2/grub.cfg-$net_default_mac"
 configfile "grub2/grub.cfg-$net_default_mac"
 


### PR DESCRIPTION
Continuing testing UEFI HTTP Boot now with Discovery. It also needs to be
booted with the given prefix, so this change creates four different global
entries and user must pick the correct default value in order to boot into
discovery.