### PR TITLE
Refs #22742 - use nic_delay.present? instead of nic_delay?

### DIFF
--- a/provisioning_templates/PXEGrub/kickstart_default_pxegrub.erb
+++ b/provisioning_templates/PXEGrub/kickstart_default_pxegrub.erb
@@ -43,7 +43,7 @@ oses:
       }
     end
   end
-  if subnet.nic_delay?
+  if subnet.nic_delay.present?
     options.push("linksleep=#{subnet.nic_delay}")
   end
 

--- a/provisioning_templates/PXEGrub2/kickstart_default_pxegrub2.erb
+++ b/provisioning_templates/PXEGrub2/kickstart_default_pxegrub2.erb
@@ -43,7 +43,7 @@ oses:
       }
     end
   end
-  if subnet.nic_delay?
+  if subnet.nic_delay.present?
     options.push("linksleep=#{subnet.nic_delay}")
   end
 

--- a/provisioning_templates/PXELinux/kickstart_default_pxelinux.erb
+++ b/provisioning_templates/PXELinux/kickstart_default_pxelinux.erb
@@ -43,7 +43,7 @@ oses:
       }
     end
   end
-  if subnet.nic_delay?
+  if subnet.nic_delay.present?
     options.push("linksleep=#{subnet.nic_delay}")
   end
 

--- a/provisioning_templates/iPXE/kickstart_default_ipxe.erb
+++ b/provisioning_templates/iPXE/kickstart_default_ipxe.erb
@@ -15,7 +15,7 @@ oses:
   <% static_arg = 'static=yes' -%>
   <% static = (@host.token.nil? ? '?' : '&') + static_arg -%>
 <% end -%>
-<% if subnet.nic_delay? -%>
+<% if subnet.nic_delay.present? -%>
   <% nic_delay = "linksleep=#{subnet.nic_delay}" -%>
 <% else -%>
   <% nic_delay = '' -%>


### PR DESCRIPTION
`Subnet#nic_delay?` is not permitted by safemode jail.