### PR TITLE
Update kickstart_default.erb

### DIFF
--- a/provisioning_templates/provision/kickstart_default.erb
+++ b/provisioning_templates/provision/kickstart_default.erb
@@ -84,6 +84,7 @@ liveimg --url=<%= liveimg_url %> <%= proxy_string %>
 <% @additional_media.each do |medium| -%>
 repo --name <%= medium[:name] %> --baseurl <%= medium[:url] %> <%= medium[:install] ? ' --install' : '' %><%= proxy_string %>
 <% end -%>
+<%= snippet_if_exists(template_name + " custom repositories") %>
 <% end %>
 lang <%= host_param('lang') || 'en_US.UTF-8' %>
 selinux --<%= host_param('selinux-mode') || host_param('selinux') || 'enforcing' %>


### PR DESCRIPTION
Add a "custom repositories" hook into the Kickstart default provisioning template to allow local customization of repositories available during the anaconda initial package install phase.  This is my suggested location, it may be appropriate to move the snippet call up or down.