### PR TITLE
Fixes #28156 - properly specify requirements

### DIFF
--- a/report_templates/ansible_inventory.erb
+++ b/report_templates/ansible_inventory.erb
@@ -10,7 +10,7 @@ template_inputs:
   advanced: false
   value_type: plain
   options: "yes\r\nno"
-  default: yes
+  default: "yes"
 - name: Location
   required: true
   input_type: user
@@ -18,7 +18,7 @@ template_inputs:
   advanced: false
   value_type: plain
   options: "yes\r\nno"
-  default: yes
+  default: "yes"
 - name: Host Group
   required: true
   input_type: user
@@ -26,7 +26,7 @@ template_inputs:
   advanced: false
   value_type: plain
   options: "yes\r\nno"
-  default: yes
+  default: "yes"
 - name: Host Collections
   required: true
   input_type: user
@@ -34,7 +34,7 @@ template_inputs:
   advanced: false
   value_type: plain
   options: "yes\r\nno"
-  default: yes
+  default: "yes"
 - name: IPv4
   required: true
   input_type: user
@@ -42,7 +42,7 @@ template_inputs:
   advanced: false
   value_type: plain
   options: "yes\r\nno"
-  default: yes
+  default: "yes"
 - name: IPv6
   required: true
   input_type: user
@@ -50,7 +50,7 @@ template_inputs:
   advanced: false
   value_type: plain
   options: "yes\r\nno"
-  default: no
+  default: "no"
 - name: Subnet
   required: true
   input_type: user
@@ -58,7 +58,7 @@ template_inputs:
   advanced: false
   value_type: plain
   options: "yes\r\nno"
-  default: yes
+  default: "yes"
 - name: Subnet v6
   required: true
   input_type: user
@@ -66,7 +66,7 @@ template_inputs:
   advanced: false
   value_type: plain
   options: "yes\r\nno"
-  default: no
+  default: "no"
 - name: Smart Proxies
   required: true
   input_type: user
@@ -74,7 +74,7 @@ template_inputs:
   advanced: false
   value_type: plain
   options: "yes\r\nno"
-  default: yes
+  default: "yes"
 - name: Content Attributes
   required: true
   input_type: user
@@ -82,7 +82,7 @@ template_inputs:
   advanced: false
   value_type: plain
   options: "yes\r\nno"
-  default: no
+  default: "no"
 - name: Facts
   required: true
   input_type: user
@@ -90,7 +90,7 @@ template_inputs:
   advanced: false
   value_type: plain
   options: "yes\r\nno"
-  default: no
+  default: "no"
 - name: Hosts
   required: false
   input_type: user
@@ -102,9 +102,9 @@ template_inputs:
 model: ReportTemplate
 require:
 - plugin: foreman_ansible
-  version: '>= 3.1.0'
+  version: '3.1.0'
 - plugin: katello
-  version: '>= 3.9.0'
+  version: '3.9.0'
 -%>
 <%- content_attrs = input('Content Attributes') == 'yes' %>
 <%- load_hosts(search: input('Hosts'), includes: [:organization, :location, :hostgroup, :host_collections, { interfaces: :subnet }, :content_facet]).each_record do |host| -%>

--- a/report_templates/ansible_inventory.erb
+++ b/report_templates/ansible_inventory.erb
@@ -35,6 +35,14 @@ template_inputs:
   value_type: plain
   options: "yes\r\nno"
   default: "yes"
+- name: Host Parameters
+  required: true
+  input_type: user
+  description: Whether should be Host Parameters included.
+  advanced: false
+  value_type: plain
+  options: "yes\r\nno"
+  default: "no"
 - name: IPv4
   required: true
   input_type: user
@@ -107,7 +115,11 @@ require:
   version: '3.9.0'
 -%>
 <%- content_attrs = input('Content Attributes') == 'yes' %>
-<%- load_hosts(search: input('Hosts'), includes: [:organization, :location, :hostgroup, :host_collections, { interfaces: :subnet }, :content_facet]).each_record do |host| -%>
+<%- interface_includes = [:subnet] %>
+<%- interface_includes.push(:domain) if input('Host Parameters') == 'yes' %>
+<%- includes = [:organization, :location, :hostgroup, :host_collections, { interfaces: interface_includes }, :content_facet] %>
+<%- includes.push(:operatingsystem) if input('Host Parameters') == 'yes' %>
+<%- load_hosts(search: input('Hosts'), includes: includes).each_record do |host| -%>
 <%-   content_facet = host_content_facet(host) if content_attrs -%>
 <%-   content_attribute_data = nil -%>
 <%-   if content_facet -%>
@@ -140,13 +152,14 @@ require:
 }
 -%>
 <%-   end -%>
-<%-   inventory_data = { 'name': host.name }
+<%-   inventory_data = { 'id': host.id, 'name': host.name }
       inventory_data.update('organization': host.organization) if input('Organization') == 'yes'
       inventory_data.update('location': host.location) if input('Location') == 'yes'
       hostgroup = host.hostgroup.title if host.hostgroup
       inventory_data.update('host_group': hostgroup) if input('Host Group') == 'yes'
       host_collections = host.host_collections.map { |c| c.name } if host.host_collections
       inventory_data.update('host_collections': host_collections) if input('Host Collections') == 'yes'
+      inventory_data.update('host_parameters': host.params) if input('Host Parameters') == 'yes'
       inventory_data.update('ipv4': host.ip) if input('IPv4') == 'yes'
       inventory_data.update('ipv6': host.ip6) if input('IPv6') == 'yes'
       inventory_data.update('subnet': host.subnet) if input('Subnet') == 'yes'


### PR DESCRIPTION
Only version number can be specified, they always mean minimum version.
Also default value of yes or no needs to be wrapped in quotes so it's
considered a String by YAML. Otherwise it auto converts it to true/false
which then fails validation of the default being one of defined options
(yes/no).

(cherry picked from commit 8b1c8a4be7807d0e39498c64f6d8f422f7a5edf9)