### PR TITLE
Remove ignoreschedules from puppet.conf

### DIFF
--- a/provisioning_templates/snippet/puppet.conf.erb
+++ b/provisioning_templates/snippet/puppet.conf.erb
@@ -47,7 +47,6 @@ digest_algorithm = sha256
 [agent]
 pluginsync      = true
 report          = true
-ignoreschedules = true
 <%- if @host.puppet_ca_server.strip -%>
 ca_server       = <%= @host.puppet_ca_server %>
 <%- end -%>


### PR DESCRIPTION
As per [this discussion](https://community.theforeman.org/t/question-why-ignoreschedules-in-puppet-conf/15362/4) `ignoreschedules = true` seems to be a leftover from some forgotten time. Schedules can not be set through Foreman as it is an ENC. However, schedules in included classes most likely don't want to be ignored by default. `ignoreschedules` seems to be a debugging option, not something that should be permanently on.