### PR TITLE
Remove fedora-everything repo definition

### DIFF
--- a/provisioning_templates/provision/kickstart_default.erb
+++ b/provisioning_templates/provision/kickstart_default.erb
@@ -125,10 +125,6 @@ services --disabled gpm,sendmail,cups,pcmcia,isdn,rawdevices,hpoj,bluetooth,open
 realm join --one-time-password='<%= @host.otp || "$HOST[OTP]" %>' <%= @host.realm %>
 <% end -%>
 
-<% if @host.operatingsystem.name == 'Fedora' -%>
-repo --name=fedora-everything --mirrorlist=https://mirrors.fedoraproject.org/metalink?repo=fedora-<%= @host.operatingsystem.major %>&arch=<%= @host.architecture %><%= proxy_string %>
-<% end -%>
-
 <% if @host.operatingsystem.name == 'OracleLinux' && os_major == 7 && os_minor < 5 -%>
 repo --name="Server-Mysql"
 <% end -%>


### PR DESCRIPTION
I don't know why this is there but user reports that it is causing troubles when installing Fedora from local mirrors. This does not need to be there, Anaconda should set them up automatically.