### PR TITLE
Change variable used to populate ksdevice parameter

### DIFF
--- a/provisioning_templates/iPXE/kickstart_default_ipxe.erb
+++ b/provisioning_templates/iPXE/kickstart_default_ipxe.erb
@@ -49,7 +49,7 @@ oses:
     options.push('fips=1')
   end
 -%>
-kernel <%= "#{@host.url_for_boot(:kernel)}" %> initrd=initrd.img ks=<%= foreman_url('provision')%><%= static %> inst.stage2=<%= medium_uri %> <%= stage2 %> ksdevice=<%= @host.mac %> network kssendmac ks.sendmac inst.ks.sendmac <%= options.join(' ') %>
+kernel <%= "#{@host.url_for_boot(:kernel)}" %> initrd=initrd.img ks=<%= foreman_url('provision')%><%= static %> inst.stage2=<%= medium_uri %> <%= stage2 %> ksdevice=<%= mac %> network kssendmac ks.sendmac inst.ks.sendmac <%= options.join(' ') %>
 initrd <%= "#{@host.url_for_boot(:initrd)}" %>
 imgstat
 sleep 2


### PR DESCRIPTION
Replace @host.mac variable by the variable mac, defined on the beginning of the template and which is properly defined as the mac address of the provision interface.