### PR TITLE
Use Github Actions to label based on paths

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,5 @@
+Remote execution:
+  - job_templates/**/*
+Provisioning:
+  - partition_tables_templates/**/*
+  - provisioning_templates/**/*

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,11 @@
+name: "Pull Request Labeler"
+on:
+- pull_request
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v2
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Previously we had our own implementation in our PRProcessor but this allows dropping that code in favor of a generic implementation.