### PR TITLE
Fixes #28518 - Correct kickstart_default logging

### DIFF
--- a/provisioning_templates/provision/kickstart_default.erb
+++ b/provisioning_templates/provision/kickstart_default.erb
@@ -200,7 +200,7 @@ cp -va /etc/resolv.conf /mnt/sysimage/etc/resolv.conf
 <%#
 Main post script, if it fails the last post is still executed.
 %>
-%post --log=/mnt/sysimage/root/install.post.log
+%post --log=/root/install.post.log
 logger "Starting anaconda <%= @host %> postinstall"
 exec < /dev/tty3 > /dev/tty3
 #changing to VT 3 so that we can see whats going on....
@@ -284,10 +284,10 @@ The last post section halts Anaconda to prevent endless loop
 <% end -%>
 if test -f /tmp/foreman_built; then
   echo "calling home: build is done!"
-  <%= indent(2, skip1: true) { snippet('built', :variables => { :endpoint => 'built', :method => 'POST', :body_file => '/mnt/sysimage/root/install.post.log' }) } -%>
+  <%= indent(2, skip1: true) { snippet('built', :variables => { :endpoint => 'built', :method => 'POST', :body_file => '/root/install.post.log' }) } -%>
 else
   echo "calling home: build failed!"
-  <%= indent(2, skip1: true) { snippet('built', :variables => { :endpoint => 'failed', :method => 'POST', :body_file => '/mnt/sysimage/root/install.post.log' }) } -%>
+  <%= indent(2, skip1: true) { snippet('built', :variables => { :endpoint => 'failed', :method => 'POST', :body_file => '/root/install.post.log' }) } -%>
 fi
 
 sync


### PR DESCRIPTION
Signed-off-by: Rohan Arora <roarora@redhat.com>

%post section already runs in a chroot environment. So post logs should be in /root instead of /mnt/sysimage