### PR TITLE
Fixes #28637 - set minimal headers for empty reports

### DIFF
--- a/report_templates/ansible_inventory.erb
+++ b/report_templates/ansible_inventory.erb
@@ -114,6 +114,7 @@ require:
 - plugin: katello
   version: '3.9.0'
 -%>
+<%- report_headers 'id', 'name' -%>
 <%- content_attrs = input('Content Attributes') == 'yes' %>
 <%- interface_includes = [:subnet] %>
 <%- interface_includes.push(:domain) if input('Host Parameters') == 'yes' %>

--- a/report_templates/applicable_errata.erb
+++ b/report_templates/applicable_errata.erb
@@ -21,6 +21,7 @@ require:
 - plugin: katello
 ￼ version: 3.9.0
 -%>
+<%- report_headers 'Host', 'Operating System', 'Environment', 'Erratum', 'Type', 'Published', 'Applicable since', 'Severity', 'Packages', 'CVEs', 'Reboot suggested' -%>
 <%- load_hosts(search: input('Hosts filter'), includes: [:operatingsystem, :applicable_errata, :lifecycle_environment]).each_record do |host| -%>
 <%-   host_applicable_errata_filtered(host, input('Errata filter')).each do |erratum| -%>
 <%-     report_row(

--- a/report_templates/applied_errata.erb
+++ b/report_templates/applied_errata.erb
@@ -45,6 +45,7 @@ require:
 - plugin: katello
   version: 3.12.0
 -%>
+<%- report_headers 'date', 'hostname', 'erratum_id', 'erratum_type', 'status' -%>
 <%- load_errata_applications(filter_errata_type: input('Filter Errata Type'), 
                              include_last_reboot: input('Include Last Reboot'),
                              since: input('Since'),

--- a/report_templates/entitlements.erb
+++ b/report_templates/entitlements.erb
@@ -6,6 +6,9 @@ require:
 - plugin: katello
   version: 3.14.0
 -%>
+<%- report_headers 'Name', 'Organization', 'Lifecycle Environment', 'Content View', 'Host Collections', 'Virtual', 'Guest of Host', 'OS', 
+'Arch', 'Sockets', 'RAM', 'Cores', 'SLA', 'Products', 'Subscription Name', 'Subscription Type', 'Subscription Quantity', 
+'Subscription SKU', 'Subscription Contract', 'Subscription Account', 'Subscription Start', 'Subscription End', 'Subscription Guest' -%>
 <%- load_hosts(includes: [:lifecycle_environment, :operatingsystem, :architecture, :content_view, :organization, :reported_data, :subscription_facet, :pools => [:subscription]]).each_record do |host| -%>
 <%-   host.pools.each do |pool| -%>
 <%-     report_row(

--- a/report_templates/host_statuses.erb
+++ b/report_templates/host_statuses.erb
@@ -12,6 +12,7 @@ template_inputs:
   resource_type: Host
 model: ReportTemplate
 -%>
+<%- report_headers 'Name', 'Global' -%>
 <%- load_hosts(search: input('hosts'), includes: :host_statuses).each_record do |host| -%>
 <%-   report_row({
         'Name': host.name,

--- a/report_templates/registered_hosts.erb
+++ b/report_templates/registered_hosts.erb
@@ -15,6 +15,7 @@ require:
 - plugin: katello
 ￼ version: 3.9.0
 -%>
+<%- report_hraders 'Name', 'Ip', 'Operating System', 'Subscriptions', 'Applicable Errata', 'Owner', 'Kernel', 'Latest kernel available' -%>
 <%- load_hosts(search: input('Hosts filter'), includes: [:operatingsystem, :subscriptions, :interfaces, :applicable_errata], preload: [:kernel_release, :owner]).each_record do |host| -%>
 <%-   report_row(
         'Name': host.name,

--- a/report_templates/subscriptions.erb
+++ b/report_templates/subscriptions.erb
@@ -13,6 +13,7 @@ require:
 - plugin: katello
 ￼ version: 3.9.0
 -%>
+<%- report_headers 'ID', 'Name', 'Available', 'Quantity', 'SKU', 'Contract number' -%>
 <%- load_pools(search: input('Subscriptions filter'), includes: [:subscription, :products]).each_record do |pool| -%>
 <%-   report_row(
         'ID': pool.id,


### PR DESCRIPTION
When the report does not render any row, resulting file does not have
any headers. This can be confusing for users, so render_headers macro
was added. It should specify column names that user should always see.
In case some columns are added dynamically, and report_row adds some
additional columns, they are added on demand. Meaning, if we iterate
over some data, new columns can be still added.