### PR TITLE
Fixes #28797 - fix subscription qty in entitlement report

### DIFF
--- a/report_templates/entitlements.erb
+++ b/report_templates/entitlements.erb
@@ -25,7 +25,7 @@ require:
           'Products': host_products(host),
           'Subscription Name': sub_name(pool),
           'Subscription Type': pool.type,
-          'Subscription Quantity': pool.quantity,
+          'Subscription Quantity': pool.consumed,
           'Subscription SKU': sub_sku(pool),
           'Subscription Contract': pool.contract_number,
           'Subscription Account': pool.account_number,


### PR DESCRIPTION
As per the current implementation of entitlement report Quantity shown here https://github.com/theforeman/community-templates/blob/7c2ee7a486a534ca54e4f37173778f5134ff3cc5/report_templates/entitlements.erb#L28 is the total quantity of that specific subscription from the Pool.

It is required to show the quantity **consumed** not the over-all quantity of the Subscription pool.
