### PR TITLE
Fixes #28896 Add template name to kickstart provision templates

### DIFF
--- a/provisioning_templates/provision/kickstart_default.erb
+++ b/provisioning_templates/provision/kickstart_default.erb
@@ -34,7 +34,7 @@ https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/6/html/in
 https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/installation_guide/sect-kickstart-syntax
 %>
 
-# This kickstart file was rendered from provisioning template "<%= @template_name %>".
+# This kickstart file was rendered from the Foreman provisioning template "<%= @template_name %>".
 
 <%
   rhel_compatible = @host.operatingsystem.family == 'Redhat' && @host.operatingsystem.name != 'Fedora'

--- a/provisioning_templates/provision/kickstart_default.erb
+++ b/provisioning_templates/provision/kickstart_default.erb
@@ -33,7 +33,9 @@ Reference links:
 https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/6/html/installation_guide/s1-kickstart2-options
 https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/installation_guide/sect-kickstart-syntax
 %>
-# <%= @template_name %>
+
+# This kickstart file was rendered from provisioning template "<%= @template_name %>".
+
 <%
   rhel_compatible = @host.operatingsystem.family == 'Redhat' && @host.operatingsystem.name != 'Fedora'
   is_fedora = @host.operatingsystem.name == 'Fedora'

--- a/provisioning_templates/provision/kickstart_default.erb
+++ b/provisioning_templates/provision/kickstart_default.erb
@@ -33,6 +33,7 @@ Reference links:
 https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/6/html/installation_guide/s1-kickstart2-options
 https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/installation_guide/sect-kickstart-syntax
 %>
+# <%= @template_name %>
 <%
   rhel_compatible = @host.operatingsystem.family == 'Redhat' && @host.operatingsystem.name != 'Fedora'
   is_fedora = @host.operatingsystem.name == 'Fedora'

--- a/provisioning_templates/provision/kickstart_ovirt.erb
+++ b/provisioning_templates/provision/kickstart_ovirt.erb
@@ -35,7 +35,8 @@ In this case, this repository would need to be part of the content
 view the host is assigned to. It's also possible to provide full url,
 in which case it would be used without a change.
 %>
-# <%= @template_name %>
+
+# This kickstart file was rendered from provisioning template "<%= @template_name %>".
 
 install
 <%

--- a/provisioning_templates/provision/kickstart_ovirt.erb
+++ b/provisioning_templates/provision/kickstart_ovirt.erb
@@ -35,6 +35,7 @@ In this case, this repository would need to be part of the content
 view the host is assigned to. It's also possible to provide full url,
 in which case it would be used without a change.
 %>
+# <%= @template_name %>
 
 install
 <%

--- a/provisioning_templates/provision/kickstart_ovirt.erb
+++ b/provisioning_templates/provision/kickstart_ovirt.erb
@@ -36,7 +36,7 @@ view the host is assigned to. It's also possible to provide full url,
 in which case it would be used without a change.
 %>
 
-# This kickstart file was rendered from provisioning template "<%= @template_name %>".
+# This kickstart file was rendered from the Foreman provisioning template "<%= @template_name %>".
 
 install
 <%


### PR DESCRIPTION
**Description**
Display name of the kickstart template in the `/root/original-ks.cfg` file.