### PR TITLE
Fix virtual nic configuration in preseed

### DIFF
--- a/provisioning_templates/snippet/preseed_networking_setup.erb
+++ b/provisioning_templates/snippet/preseed_networking_setup.erb
@@ -47,7 +47,7 @@ EOF
 real=`ip -o link | awk '/<%= interface.mac -%>/ {print $2;}' | sed s/:$//`
 <% virtual = interface.virtual? -%>
 <% if virtual -%>
-real=`echo <%= interface.identifier -%> | sed s/<%= interface.attached_to -%>/$real/`
+real="<%= interface.attached_to -%>"
 <% end -%>
 
 cat << EOF >> /etc/network/interfaces


### PR DESCRIPTION
The `ifconfig` way of configuring virtual-NICs (multiple IPs on one interface) on Debian distributions no longer works with recent versions:
https://wiki.debian.org/NetworkConfiguration#Multiple_IP_addresses_on_one_Interface