### PR TITLE
Fixes #29191 - Use medium_uri.to_s in Kickstart default iPXE

### DIFF
--- a/provisioning_templates/iPXE/kickstart_default_ipxe.erb
+++ b/provisioning_templates/iPXE/kickstart_default_ipxe.erb
@@ -29,7 +29,7 @@ oses:
 
   options.push("linksleep=#{subnet.nic_delay}") if subnet.nic_delay.present?
 
-  stage2 = host_param('kickstart_liveimg') ? 'inst.stage2=' + medium_uri : ''
+  stage2 = host_param('kickstart_liveimg') ? 'inst.stage2=' + medium_uri.to_s : ''
 
   if (is_fedora && os_major < 17) || (rhel_compatible && os_major < 7)
     options.push('ip=${netX/ip} netmask=${netX/netmask} gateway=${netX/gateway} dns=${dns}')


### PR DESCRIPTION
@lzap, not related to this PR, but I've noticed that in this template `stage2` option generated twice with the same value.

https://github.com/ofedoren/community-templates/blob/develop/provisioning_templates/iPXE/kickstart_default_ipxe.erb#L32 will set `inst.stage2` to `medium_uri` if host has `kickstart_liveimg` parameter set.

But also in https://github.com/ofedoren/community-templates/blob/develop/provisioning_templates/iPXE/kickstart_default_ipxe.erb#L52 the `inst.stage2` option will be always set to `medium_uri` (`inst.stage2=<%= medium_uri %>`)

Which makes me wonder if we rather should change the https://github.com/ofedoren/community-templates/blob/develop/provisioning_templates/iPXE/kickstart_default_ipxe.erb#L32 to something like
```ruby
stage2 = host_param('kickstart_liveimg') ? 'inst.stage2=' + host_param('kickstart_liveimg') : ''
```

Please correct me if I'm wrong.