### PR TITLE
Fixes #29260 - Add -y flag for yum command

### DIFF
--- a/job_templates/install_errata_-_katello_ansible_default.erb
+++ b/job_templates/install_errata_-_katello_ansible_default.erb
@@ -15,4 +15,4 @@ kind: job_template
 %>
 
 <% advisories = input(:errata).split(',').map { |e| "--advisory=#{e}" }.join(' ') %>
-<%= render_template('Run Command - Ansible Default', :command => "yum update-minimal #{advisories}") %>
+<%= render_template('Run Command - Ansible Default', :command => "yum -y update-minimal #{advisories}") %>

--- a/job_templates/install_group_-_katello_ansible_default.erb
+++ b/job_templates/install_group_-_katello_ansible_default.erb
@@ -13,4 +13,4 @@ provider_type: Ansible
 kind: job_template
 %>
 
-<%= render_template('Run Command - Ansible Default', :command => "yum group install #{input('package')}") %>
+<%= render_template('Run Command - Ansible Default', :command => "yum -y group install #{input('package')}") %>

--- a/job_templates/remove_group_-_katello_ansible_default.erb
+++ b/job_templates/remove_group_-_katello_ansible_default.erb
@@ -13,4 +13,4 @@ provider_type: Ansible
 kind: job_template
 %>
 
-<%= render_template('Run Command - Ansible Default', :command => "yum group remove #{input('package')}") %>
+<%= render_template('Run Command - Ansible Default', :command => "yum -y group remove #{input('package')}") %>

--- a/job_templates/update_group_-_katello_ansible_default.erb
+++ b/job_templates/update_group_-_katello_ansible_default.erb
@@ -13,4 +13,4 @@ provider_type: Ansible
 kind: job_template
 %>
 
-<%= render_template('Run Command - Ansible Default', :command => "yum group update #{input('package')}") %>
+<%= render_template('Run Command - Ansible Default', :command => "yum -y group update #{input('package')}") %>

--- a/job_templates/update_package_-_katello_ansible_default.erb
+++ b/job_templates/update_package_-_katello_ansible_default.erb
@@ -13,4 +13,4 @@ provider_type: Ansible
 kind: job_template
 %>
 
-<%= render_template('Run Command - Ansible Default', :command => "yum update #{input('package')}") %>
+<%= render_template('Run Command - Ansible Default', :command => "yum -y update #{input('package')}") %>


### PR DESCRIPTION
Hi there,

Same as : https://github.com/Katello/katello/pull/8599

As described in : https://projects.theforeman.org/issues/29260
And https://community.theforeman.org/t/using-sudo-su-for-privilege-escalation/17635/4

The Katello Ansible Default templates that are using Ansible shell commands directly for creating Yum action like update are missing a "-y" flag which makes them hang

This fixes the problem by adding the missing -y flag on each template that was missing it.

The files here and on the Katello repository are identical

regards,

Thomas