### PR TITLE
Use correct role name for deploying receptor

### DIFF
--- a/job_templates/connect_red_hat_receptor_controller_-_ansible_default.erb
+++ b/job_templates/connect_red_hat_receptor_controller_-_ansible_default.erb
@@ -23,4 +23,4 @@ kind: job_template
   vars:
     satellite_url: "<%= foreman_server_url %>"
   roles:
-    - satellite-receptor
+    - project-receptor.satellite_receptor_installer


### PR DESCRIPTION
We expected the role to be receptor-satellite, however it was published on ansible-galaxy as `project-receptor.satellite_receptor_installer`.