### PR TITLE
Fixes #29469 - Add Capsule upgrade playbook template

### DIFF
--- a/job_templates/capsule_upgrade_-_ansible_default.erb
+++ b/job_templates/capsule_upgrade_-_ansible_default.erb
@@ -1,0 +1,51 @@
+<%#
+name: Smart Proxy Upgrade Playbook
+snippet: false
+template_inputs:
+- name: target_version
+  required: true
+  input_type: user
+  advanced: false
+  value_type: plain
+  hidden_value: false
+- name: whitelist_options
+  required: false
+  input_type: user
+  advanced: false
+  value_type: plain
+  hidden_value: false
+model: JobTemplate
+job_category: Ansible Playbook
+description_format: "%{template_name}"
+provider_type: Ansible
+kind: job_template
+%>
+
+---
+- hosts: all
+  tasks:
+    - name: Gather the rpm package facts
+      package_facts:
+        manager: auto
+
+    - name: Fail if the target server is a Satellite server
+      fail:
+        msg: "This playbook cannot be executed on a Satellite server. Use only on a Capsule server."
+      when: "'satellite' in ansible_facts.packages"
+
+    - block:
+      - name: Upgrade Smart Proxy using foreman-maintain
+        command: foreman-maintain upgrade run --assumeyes --target-version=<%= input('target_version') %> --whitelist="<%= input('whitelist_options') %>"
+        register: result
+
+      - name: foreman-maintain upgrade return code is zero
+        debug:
+          msg: "Success! Smart Proxy upgrade completed."
+      rescue:
+        - name: Print foreman-maintain output
+          debug:
+            var: result
+
+        - name: foreman-maintain upgrade return code is non-zero
+          fail:
+            msg: "Failed! Smart Proxy upgrade failed. See /var/log/foreman-installer/ in the Smart Proxy server for more information"

--- a/job_templates/capsule_upgrade_-_ansible_default.erb
+++ b/job_templates/capsule_upgrade_-_ansible_default.erb
@@ -33,26 +33,38 @@ kind: job_template
         msg: "This playbook cannot be executed on a Satellite server. Use only on a Capsule server."
       when: "'satellite' in ansible_facts.packages"
 
-    - name: Install foreman-maintain if not present
+    - name: Install satellite-maintain if not present
       package:
         name: rubygem-foreman_maintain
         state: present
       when: "'rubygem-foreman_maintain' not in ansible_facts.packages"
 
     - block:
-      - name: Upgrade Capsule server using foreman-maintain
-        command: foreman-maintain upgrade run --assumeyes --target-version=<%= input('target_version') %> --whitelist="<%= input('whitelist_options') %>"
+      - name: Upgrade Capsule server using satellite-maintain
+        shell: satellite-maintain upgrade run --assumeyes --target-version=<%= input('target_version') %> --whitelist="<%= input('whitelist_options') %>"
         register: result
 
-      - name: foreman-maintain upgrade return code is zero
+      - name: Re-Gather the rpm package facts after the upgrade
+        package_facts:
+          manager: auto
+
+      - name: satellite-maintain upgrade return code is zero
         debug:
           msg: "Success! Capsule server upgrade completed. Current version of Capsule server server is {{ ansible_facts.packages['satellite-capsule'][0]['version'] }}."
 
       rescue:
-        - name: Print foreman-maintain output
+        - name: Print satellite-maintain output
           debug:
             var: result
 
-        - name: foreman-maintain upgrade return code is non-zero
+        - name: Grep top 10 Error messages from /var/log/foreman-installer/capsule.log
+          shell: grep '^\[ERROR' /var/log/foreman-installer/capsule.log | head -n10
+          register: output_grep
+
+        - name: Print grepped Error messages
+          debug:
+            var: output_grep.stdout_lines
+
+        - name: satellite-maintain upgrade return code is non-zero
           fail:
             msg: "Failed! Capsule server upgrade failed. See /var/log/foreman-installer/capsule.log in the Capsule server for more information"

--- a/job_templates/capsule_upgrade_-_ansible_default.erb
+++ b/job_templates/capsule_upgrade_-_ansible_default.erb
@@ -1,5 +1,5 @@
 <%#
-name: Smart Proxy Upgrade Playbook
+name: Capsule Upgrade Playbook
 snippet: false
 template_inputs:
 - name: target_version
@@ -34,13 +34,13 @@ kind: job_template
       when: "'satellite' in ansible_facts.packages"
 
     - block:
-      - name: Upgrade Smart Proxy using foreman-maintain
+      - name: Upgrade Capsule server using foreman-maintain
         command: foreman-maintain upgrade run --assumeyes --target-version=<%= input('target_version') %> --whitelist="<%= input('whitelist_options') %>"
         register: result
 
       - name: foreman-maintain upgrade return code is zero
         debug:
-          msg: "Success! Smart Proxy upgrade completed. Current version of Smart Proxy server is {{ ansible_facts.packages['satellite-capsule'][0]['version'] }}."
+          msg: "Success! Capsule server upgrade completed. Current version of Capsule server server is {{ ansible_facts.packages['satellite-capsule'][0]['version'] }}."
 
       rescue:
         - name: Print foreman-maintain output
@@ -49,4 +49,4 @@ kind: job_template
 
         - name: foreman-maintain upgrade return code is non-zero
           fail:
-            msg: "Failed! Smart Proxy upgrade failed. See /var/log/foreman-installer/ in the Smart Proxy server for more information"
+            msg: "Failed! Capsule server upgrade failed. See /var/log/foreman-installer/capsule.log in the Capsule server for more information"

--- a/job_templates/capsule_upgrade_-_ansible_default.erb
+++ b/job_templates/capsule_upgrade_-_ansible_default.erb
@@ -33,6 +33,12 @@ kind: job_template
         msg: "This playbook cannot be executed on a Satellite server. Use only on a Capsule server."
       when: "'satellite' in ansible_facts.packages"
 
+    - name: Install foreman-maintain if not present
+      package:
+        name: rubygem-foreman_maintain
+        state: present
+      when: "'rubygem-foreman_maintain' not in ansible_facts.packages"
+
     - block:
       - name: Upgrade Capsule server using foreman-maintain
         command: foreman-maintain upgrade run --assumeyes --target-version=<%= input('target_version') %> --whitelist="<%= input('whitelist_options') %>"

--- a/job_templates/capsule_upgrade_-_ansible_default.erb
+++ b/job_templates/capsule_upgrade_-_ansible_default.erb
@@ -40,7 +40,8 @@ kind: job_template
 
       - name: foreman-maintain upgrade return code is zero
         debug:
-          msg: "Success! Smart Proxy upgrade completed."
+          msg: "Success! Smart Proxy upgrade completed. Current version of Smart Proxy server is {{ ansible_facts.packages['satellite-capsule'][0]['version'] }}."
+
       rescue:
         - name: Print foreman-maintain output
           debug:


### PR DESCRIPTION
To test this on a Satellite 6.7 server:
1. Copy the erb file from the PR to the Satellite server:  `/opt/theforeman/tfm/root/usr/share/gems/gems/foreman_ansible-4.0.3.4/app/views/foreman_ansible/job_templates/`
2. Run db seed job on Satellite server: `foreman-rake db:seed`
3. To prepare your capsule server for ReX, run this from your Satellite mentioning your capsule server name:
```
ssh-copy-id -i ~foreman-proxy/.ssh/id_rsa_foreman_proxy.pub root@capsule.example.com
```
4. Run Remote Execution job using this new template:
    It will be listed in the job dropdown as:
     ```
     Job Category: Ansible Playbook
     Job Template: Capsule Upgrade Playbook
    ```
   Sample Job options:
    `target_version` = 6.7.z
    `whitelist_options` = repositories-validate,repositories-setup,disk-performance