### PR TITLE
Refs #29239 - unify discovery grub2 menu items

### DIFF
--- a/provisioning_templates/PXEGrub2/kickstart_default_pxegrub2.erb
+++ b/provisioning_templates/PXEGrub2/kickstart_default_pxegrub2.erb
@@ -31,8 +31,8 @@ menuentry '<%= template_name %>' {
 }
 
 menuentry '<%= template_name %> HTTP Boot' {
-  <%= linuxcmd %> /httpboot/<%= @kernel %> ks=<%= foreman_url('provision') %> <%= pxe_kernel_options %> <%= snippet("kickstart_kernel_options").strip %> BOOTIF=01-$net_default_mac
-  <%= initrdcmd %> /httpboot/<%= @initrd %>
+  <%= linuxcmd %> /EFI/BOOT/<%= @kernel %> ks=<%= foreman_url('provision') %> <%= pxe_kernel_options %> <%= snippet("kickstart_kernel_options").strip %> BOOTIF=01-$net_default_mac
+  <%= initrdcmd %> /EFI/BOOT/<%= @initrd %>
 }
 
 <%= snippet_if_exists(template_name + " custom menu") %>

--- a/provisioning_templates/snippet/pxegrub2_mac.erb
+++ b/provisioning_templates/snippet/pxegrub2_mac.erb
@@ -4,8 +4,8 @@ name: pxegrub2_mac
 model: ProvisioningTemplate
 snippet: true
 -%>
-echo "Trying /httpboot/grub2/grub.cfg-$net_default_mac"
-configfile "/httpboot/grub2/grub.cfg-$net_default_mac"
+echo "Trying /EFI/BOOT/grub2/grub.cfg-$net_default_mac"
+configfile "/EFI/BOOT/grub2/grub.cfg-$net_default_mac"
 
 echo "Trying /grub2/grub.cfg-$net_default_mac"
 configfile "/grub2/grub.cfg-$net_default_mac"


### PR DESCRIPTION
Path `/httpboot` is also available as `/EFI/BOOT` now which is the recommended path by Grub developers (the default one). I've already changed this in the main template but forgot this for the rest.