### PR TITLE
Fixes #29591 - Replaced the double bracket testing to builtin test

### DIFF
--- a/provisioning_templates/snippet/efibootmgr_netboot.erb
+++ b/provisioning_templates/snippet/efibootmgr_netboot.erb
@@ -6,7 +6,7 @@ description: Configure booting from network in EFI
 snippet: true
 %>
 <% if host_param('efi_bootentry') == 'previous' -%>
-if [[ -d /sys/firmware/efi ]]; then
+if [ -d /sys/firmware/efi ]; then
   echo "Changing EFI boot order to preserve boot. Typically the previous entry"
   echo "was network boot in netboot workflows but this can also break things."
   echo "In that case use efi_keep_bootorder host parameter to keep it untouched."
@@ -21,7 +21,7 @@ if [[ -d /sys/firmware/efi ]]; then
   echo
 fi
 <% elsif (entry = host_param('efi_bootentry')) -%>
-if [[ -d /sys/firmware/efi ]]; then
+if [ -d /sys/firmware/efi ]; then
   echo "Trying to find EFI boot entry containing: <%= entry -%>"
   echo "Boot order is currently:"
   efibootmgr


### PR DESCRIPTION
During testing with debian deployment on EFI hosts, we noticed that the /tmp/finish.sh throws an error: in-target: /tmp/finish.sh: 325: /tmp/finish.sh: [[: not found. Replacing the test cases with single brackets solved this problem.