### PR TITLE
Refresh subscription-manager before package installation

### DIFF
--- a/job_templates/package_action_-_ssh_default.erb
+++ b/job_templates/package_action_-_ssh_default.erb
@@ -97,6 +97,7 @@ handle_zypp_res_codes () {
       end
     end
   -%>
+  [ -x "$(command -v subscription-manager)" ] && subscription-manager refresh
   apt-get -y update
   apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -y <%= action %> <%= input("package") %>
 <% elsif package_manager == 'zypper' -%>


### PR DESCRIPTION
Refresh the state of the subscription-manager on debian based
distributions before updating the repositories and installting a
package. This will only be done if the subscription manager exists.
Refreshing the subscription manager is necessary to get the latest state
of activated (or disabled) repositories.