### PR TITLE
Add /opt/puppetlabs/bin to PATH on debian

### DIFF
--- a/job_templates/puppet_agent_disable_-_ssh_default.erb
+++ b/job_templates/puppet_agent_disable_-_ssh_default.erb
@@ -13,4 +13,7 @@ template_inputs:
 provider_type: SSH
 kind: job_template
 -%>
+<% if @host.operatingsystem.family == 'Debian' -%>
+export PATH=/opt/puppetlabs/bin:$PATH
+<% end -%>
 puppet agent --disable "<%= input("comment").present? ? input("comment") : "Disabled using Foreman Remote Execution"  %> - <%= current_user %> - $(date "+%d/%m/%Y %H:%M")"

--- a/job_templates/puppet_agent_enable_-_ssh_default.erb
+++ b/job_templates/puppet_agent_enable_-_ssh_default.erb
@@ -7,4 +7,7 @@ snippet: false
 provider_type: SSH
 kind: job_template
 -%>
+<% if @host.operatingsystem.family == 'Debian' -%>
+export PATH=/opt/puppetlabs/bin:$PATH
+<% end -%>
 puppet agent --enable

--- a/job_templates/puppet_install_modules_from_forge_-_ssh_default.erb
+++ b/job_templates/puppet_install_modules_from_forge_-_ssh_default.erb
@@ -33,4 +33,7 @@ template_inputs:
 provider_type: SSH
 kind: job_template
 -%>
+<% if @host.operatingsystem.family == 'Debian' -%>
+export PATH=/opt/puppetlabs/bin:$PATH
+<% end -%>
 puppet module install <%= input('puppet_module') %> <%= "--target-dir #{input('target_dir')}" if input('target_dir').present? %> <%= "--version #{input('version')}" if input('version').present? %> <%= "--force" if input('force') == "true" %> <%= "--ignore-dependencies" if input('ignore_dependencies') == "true" %>

--- a/job_templates/puppet_run_once_-_ansible_default.erb
+++ b/job_templates/puppet_run_once_-_ansible_default.erb
@@ -18,4 +18,8 @@ model: JobTemplate
 - hosts: all
   tasks:
     - command: |
-        puppet agent --onetime --no-usecacheonfailure --no-daemonize <%= input("puppet_options") %>
+        puppet agent --onetime --no-usecacheonfailure --no-daemonize <%= input("puppet_options") -%>
+<% if @host.operatingsystem.family == 'Debian' -%>
+      environment:
+        PATH: "/opt/puppetlabs/bin:{{ (ansible_env|default({})).PATH|default('') }}"
+<% end -%>

--- a/job_templates/puppet_run_once_-_ssh_default.erb
+++ b/job_templates/puppet_run_once_-_ssh_default.erb
@@ -11,4 +11,7 @@ template_inputs:
   input_type: user
   required: false
 %>
+<% if @host.operatingsystem.family == 'Debian' -%>
+export PATH=/opt/puppetlabs/bin:$PATH
+<% end -%>
 puppet agent --onetime --no-usecacheonfailure --no-daemonize <%= input("puppet_options") %>


### PR DESCRIPTION
The PATH to /opt/puppetlabs/bin is not set on debian based systems as it
would be set by puppt-agent.sh in /etc/profile.d/.  On Debian based
systems, /etc/profile.d/puppet-agent.sh is not sourced on no-login
shell. No-login shell is used if you run a remote execution task.
As puppet from puppetlabs is installed in /opt/puppetlabs the REX
job fails