### PR TITLE
Deprecated foreman_url without arguments

### DIFF
--- a/provisioning_templates/provision/junos_default_slax.erb
+++ b/provisioning_templates/provision/junos_default_slax.erb
@@ -404,7 +404,7 @@ match / {
 
   expr jcs:syslog( $SYSLOG, $APPNAME, ": sending finish signal to foreman...");  
   var $do_foreman = <file-copy> {
-      <source> '<%= foreman_url %>';
+      <source> '<%= foreman_url('provision') %>';
       <destination> "/tmp";
       <staging-directory> "/tmp";
   };


### PR DESCRIPTION
Looks like we have missed one in

https://github.com/theforeman/community-templates/pull/570

Core PR:

https://github.com/theforeman/foreman/pull/7644