### PR TITLE
Update oVirt templates

### DIFF
--- a/provisioning_templates/PXELinux/kickstart_ovirt_pxelinux.erb
+++ b/provisioning_templates/PXELinux/kickstart_ovirt_pxelinux.erb
@@ -10,5 +10,5 @@ DEFAULT rhvh
 
 LABEL rhvh
 KERNEL <%= @kernel %>
-APPEND initrd=<%= @initrd %> inst.ks=<%= foreman_url("provision") %> inst.stage2=<%= medium_uri %> local_boot_trigger=<%= foreman_url("built") %> intel_iommu=on
+APPEND initrd=<%= @initrd %> <%= pxe_kernel_options %> <%= snippet("kickstart_kernel_options").strip %> ks=<%= foreman_url("provision") %> local_boot_trigger=<%= foreman_url("built") %>
 IPAPPEND 2

--- a/provisioning_templates/provision/atomic_kickstart_default.erb
+++ b/provisioning_templates/provision/atomic_kickstart_default.erb
@@ -15,7 +15,7 @@ timezone --utc <%= host_param('time-zone') || 'UTC' %>
 <% dhcp = !@static -%>
 <% end -%>
 
-network --bootproto <%= dhcp ? 'dhcp' : "static --ip=#{@host.ip} --netmask=#{subnet.mask} --gateway=#{subnet.gateway} --nameserver=#{subnet.dns_servers.join(',')} --mtu=#{subnet.mtu.to_s}" %> --hostname <%= @host %><%= " --device=#{@host.mac}" -%>
+network --bootproto <%= dhcp ? 'dhcp' : "static --ip=#{@host.provision_interface.ip} --netmask=#{subnet.mask} --gateway=#{subnet.gateway} --nameserver=#{subnet.dns_servers.join(',')} --mtu=#{subnet.mtu.to_s}" %> --hostname <%= @host %><%= " --device=#{@host.provision_interface.mac}" -%>
 
 # Partition table should create /boot and a volume atomicos
 <% if @dynamic -%>

--- a/provisioning_templates/provision/kickstart_ovirt.erb
+++ b/provisioning_templates/provision/kickstart_ovirt.erb
@@ -50,13 +50,13 @@ end
 
 liveimg --url=<%= liveimg_url %>
 
-<% subnet = @host.subnet -%>
+<% subnet = @host.provision_interface.subnet -%>
 <% if subnet.respond_to?(:dhcp_boot_mode?) -%>
 <% dhcp = subnet.dhcp_boot_mode? && !@static -%>
 <% else -%>
 <% dhcp = !@static -%>
 <% end -%>
-network --bootproto <%= dhcp ? 'dhcp' : "static --ip=#{@host.ip} --netmask=#{subnet.mask} --gateway=#{subnet.gateway} --nameserver=#{subnet.dns_servers.join(',')}" %> --hostname <%= @host %> --device=<%= @host.mac -%>
+network --bootproto <%= dhcp ? 'dhcp' : "static --ip=#{@host.provision_interface.ip} --netmask=#{subnet.mask} --gateway=#{subnet.gateway} --nameserver=#{subnet.dns_servers.join(',')}" %> --hostname <%= @host %> --device=<%= @host.provision_interface.mac -%>
 
 rootpw --iscrypted <%= root_pass %>
 <% if host_param_true?('disable-firewall') -%>
@@ -76,7 +76,11 @@ reboot
 %post --log=/root/ks.post.log --erroronfail
 nodectl init
 <%= snippet 'redhat_register' %>
+<% if host_enc['parameters']['realm'] && @host.realm && (@host.realm.realm_type == 'FreeIPA' || @host.realm.realm_type == 'Red Hat Identity Management') -%>
+<%= snippet 'freeipa_register' %>
+<% end -%>
 <%= snippet 'kickstart_networking_setup' %>
+<%= snippet('remote_execution_ssh_keys') %>
 <%= snippet 'efibootmgr_netboot' %>
 /usr/sbin/ntpdate -sub <%= host_param('ntp-server') || '0.fedora.pool.ntp.org' %>
 /usr/sbin/hwclock --systohc


### PR DESCRIPTION
Update some changes which we made in default kicsktart template in oVirt and Atomic templates. Namely instead `@host.ip` or mac which point to primary_interface, it now uses the correct provision_interface.

Also include IPA and ReX snippets for oVirt.