### PR TITLE
Add networking to cloud init

### DIFF
--- a/provisioning_templates/user_data/userdata_default.erb
+++ b/provisioning_templates/user_data/userdata_default.erb
@@ -76,6 +76,14 @@ runcmd:
 - |
 <%= indent(2) { snippet('saltstack_setup') } %>
 <% end -%>
+- |
+<%=
+  if rhel_compatible && !host_param_false?('cloudinit-networking')
+    indent(2) { snippet 'kickstart_networking_setup' }
+  else
+    indent(2) { snippet 'preseed_networking_setup' }
+  end
+%>
 
 <%# Contact Foreman to confirm instance is built -%>
 phone_home:


### PR DESCRIPTION
This is just an untested prototype - someone needs to test this. I wrote this for a customer, I don't know if networkmanager needs to be restarted or network reloaded after these changes.

We should do cloutinit networking properly some day but I have no time for investigating how this works - there are multiple formats and networking in cloud-init is simply a mess at the moment. Something should work on particular providers, something is partially generic. This workaround at least should work on redhat and debian families, there is a flag to disable this when this is irrelevant.