### PR TITLE
Replace blacklist with blocklist

### DIFF
--- a/provisioning_templates/PXEGrub2/preseed_default_pxegrub2.erb
+++ b/provisioning_templates/PXEGrub2/preseed_default_pxegrub2.erb
@@ -22,9 +22,10 @@ oses:
   os_name  = @host.operatingsystem.name
 
   options = []
-  if host_param('blacklist')
-    options << host_param('blacklist').split(',').collect{|x| "#{x.strip}.blacklist=yes"}.join(' ')
+  if host_param('blocklist_kernel_modules')
+    options << host_param('blocklist_kernel_modules').split(%r{,\s*}).collect{|x| "#{x.strip}.blacklist=yes"}.join(' ')
   end
+  raise("Host param 'blacklist' has been deprecated, use 'blocklist_kernel_modules' instead") if host_param('blacklist')
   if os_name == 'Debian'
     options << "auto=true"
     options << "domain=#{@host.domain}"

--- a/provisioning_templates/PXELinux/preseed_default_pxelinux.erb
+++ b/provisioning_templates/PXELinux/preseed_default_pxelinux.erb
@@ -19,9 +19,10 @@ oses:
 #
 <%
   options = []
-  if host_param('blacklist')
-    options << host_param('blacklist').split(',').collect{|x| "#{x.strip}.blacklist=yes"}.join(' ')
+  if host_param('blocklist_kernel_modules')
+    options << host_param('blocklist_kernel_modules').split(%r{,\s*}).collect{|x| "#{x.strip}.blacklist=yes"}.join(' ')
   end
+  raise("Host param 'blacklist' has been deprecated, use 'blocklist_kernel_modules' instead") if host_param('blacklist')
   if @host.operatingsystem.name == 'Debian'
     options << "auto=true"
     options << "domain=#{@host.domain}"

--- a/provisioning_templates/cloud_init/cloud_init_default.erb
+++ b/provisioning_templates/cloud_init/cloud_init_default.erb
@@ -48,7 +48,7 @@ runcmd:
 - |
 <%= indent(2) { snippet 'remote_execution_ssh_keys' } %>
 - |
-<%= indent(2) { snippet 'blacklist_kernel_modules' } %>
+<%= indent(2) { snippet 'blocklist_kernel_modules' } %>
 - |
 <% if chef_enabled %>
 <%= indent(2) { snippet 'chef_client' } %>

--- a/provisioning_templates/finish/kickstart_default_finish.erb
+++ b/provisioning_templates/finish/kickstart_default_finish.erb
@@ -58,7 +58,7 @@ fi
 
 <%= snippet('remote_execution_ssh_keys') %>
 
-<%= snippet "blacklist_kernel_modules" %>
+<%= snippet "blocklist_kernel_modules" %>
 
 <% if chef_enabled %>
 <%= snippet 'chef_client' %>

--- a/provisioning_templates/finish/preseed_default_finish.erb
+++ b/provisioning_templates/finish/preseed_default_finish.erb
@@ -38,7 +38,7 @@ oses:
 
 <%= snippet('remote_execution_ssh_keys') %>
 
-<%= snippet "blacklist_kernel_modules" %>
+<%= snippet "blocklist_kernel_modules" %>
 
 <% if chef_enabled %>
 <%= snippet 'chef_client' %>

--- a/provisioning_templates/provision/autoyast_default.erb
+++ b/provisioning_templates/provision/autoyast_default.erb
@@ -191,7 +191,7 @@ cp /etc/resolv.conf /mnt/etc
 
 <%= snippet('remote_execution_ssh_keys') %>
 
-<%= snippet "blacklist_kernel_modules" %>
+<%= snippet "blocklist_kernel_modules" %>
 
 <% if puppet_enabled -%>
 <%= snippet 'puppet_setup' %>

--- a/provisioning_templates/provision/autoyast_sles_default.erb
+++ b/provisioning_templates/provision/autoyast_sles_default.erb
@@ -208,7 +208,7 @@ cp /etc/resolv.conf /mnt/etc
 
 <%= snippet('remote_execution_ssh_keys') %>
 
-<%= snippet "blacklist_kernel_modules" %>
+<%= snippet "blocklist_kernel_modules" %>
 
 <% if puppet_enabled -%>
 <%= snippet 'puppet_setup' %>

--- a/provisioning_templates/provision/kickstart_default.erb
+++ b/provisioning_templates/provision/kickstart_default.erb
@@ -294,7 +294,7 @@ fi
 
 <%= snippet('remote_execution_ssh_keys') %>
 
-<%= snippet "blacklist_kernel_modules" %>
+<%= snippet "blocklist_kernel_modules" %>
 
 <% if chef_enabled %>
 <%= snippet 'chef_client' %>

--- a/provisioning_templates/snippet/blacklist_kernel_modules.erb
+++ b/provisioning_templates/snippet/blacklist_kernel_modules.erb
@@ -3,9 +3,5 @@ kind: snippet
 name: blacklist_kernel_modules
 model: ProvisioningTemplate
 snippet: true
-%>
-<% if host_param('blacklist_kernel_modules') -%>
-  <% host_param('blacklist_kernel_modules').split.each do |mod| -%>
-    echo "blacklist <%= mod %>" >> /etc/modprobe.d/blacklist.conf
-  <% end -%>
-<% end -%>
+-%>
+<% raise("Snippet 'blacklist_kernel_modules' was renamed to 'blocklist_kernel_modules', update your template.") %>

--- a/provisioning_templates/snippet/blocklist_kernel_modules.erb
+++ b/provisioning_templates/snippet/blocklist_kernel_modules.erb
@@ -1,0 +1,11 @@
+<%#
+kind: snippet
+name: blocklist_kernel_modules
+model: ProvisioningTemplate
+snippet: true
+%>
+<% if host_param('blocklist_kernel_modules') -%>
+  <% host_param('blocklist_kernel_modules').split.each do |mod| -%>
+    echo "blacklist <%= mod %>" >> /etc/modprobe.d/blocklist.conf
+  <% end -%>
+<% end -%>

--- a/provisioning_templates/user_data/autoyast_default_user_data.erb
+++ b/provisioning_templates/user_data/autoyast_default_user_data.erb
@@ -24,7 +24,7 @@ echo 'root:<%= root_pass -%>' | /usr/sbin/chpasswd -e
 
 <%= snippet('remote_execution_ssh_keys') %>
 
-<%= snippet "blacklist_kernel_modules" %>
+<%= snippet "blocklist_kernel_modules" %>
 
 <% if puppet_enabled %>
 <% if host_param_true?('enable-puppetlabs-puppet6-repo') || host_param_true?('enable-puppetlabs-puppet5-repo') -%>

--- a/provisioning_templates/user_data/kickstart_default_user_data.erb
+++ b/provisioning_templates/user_data/kickstart_default_user_data.erb
@@ -49,7 +49,7 @@ fi
 
 <%= snippet('remote_execution_ssh_keys') %>
 
-<%= snippet "blacklist_kernel_modules" %>
+<%= snippet "blocklist_kernel_modules" %>
 
 <% if chef_enabled %>
 <%= snippet 'chef_client' %>

--- a/provisioning_templates/user_data/preseed_default_user_data.erb
+++ b/provisioning_templates/user_data/preseed_default_user_data.erb
@@ -30,7 +30,7 @@ echo 'Acquire::http::Proxy "<%= proxy_uri %>";' >> /etc/apt/apt.conf
 
 <%= snippet('remote_execution_ssh_keys') %>
 
-<%= snippet "blacklist_kernel_modules" %>
+<%= snippet "blocklist_kernel_modules" %>
 
 <% if chef_enabled %>
 <%= snippet 'chef_client' %>


### PR DESCRIPTION
I was taught in schools and books about whitelist and blacklist technical terms. It felt natural and normal to me, until last couple of days. Latest developments from US and all over the world made me to realize how awful these words are. While these words might not associate anything to some of us, there are many out there who might not feel the same. Getting rid of these may be just a small gesture, but I don't want to sit doing nothing.

The patch I propose removes "blacklist" and "blacklist_kernel_modules" host parameters and replaces both with one called "blocklist_kernel_parameter". They both served the same purpose - to pass either kernel command line option `blacklist` and/or create entry in `/etc/modprobe.d/blacklist.conf`. Insted of two host params we now have a single one. On top of that, the syntax is now common, kernel modules can be separated with a comma or a whitespace, previously it was different for both parameters.

While we cannot get rid of the `blacklist` keyword in the rendered output because Linux expect these keywords as of today (summer 2020), we can trim down the exposure at least for Foreman users. That's something. In the initial proposal, using any of the previous host parameters will cause an exception asking the user to change their templates. We can talk about that, we don't have any deprecation mechanisms for templates (yet), I can create a macro called `deprecated` which drops a warning message in logs although I have doubts users would catch that until we finally drop it.