### PR TITLE
Fix installation of salt minion

### DIFF
--- a/provisioning_templates/provision/autoyast_default.erb
+++ b/provisioning_templates/provision/autoyast_default.erb
@@ -139,9 +139,6 @@ oses:
 <% if puppet_enabled -%>
       <package>rubygem-puppet</package>
 <% end -%>
-<% if salt_enabled -%>
-      <package>salt-minion</package>
-<% end -%>
     </packages>
   </software>
   <users config:type="list">

--- a/provisioning_templates/provision/autoyast_sles_default.erb
+++ b/provisioning_templates/provision/autoyast_sles_default.erb
@@ -153,9 +153,6 @@ oses:
       <package>rubygem-puppet</package>
 <% end -%>
 <% end -%>
-<% if salt_enabled -%>
-      <package>salt-minion</package>
-<% end -%>
 <% if spacewalk_enabled -%>
       <package>rhn-setup</package>
 <% end -%>
@@ -210,16 +207,16 @@ cp /etc/resolv.conf /mnt/etc
 
 <%= snippet "blacklist_kernel_modules" %>
 
+<% if spacewalk_enabled -%>
+<%= snippet 'redhat_register' %>
+<% end -%>
+
 <% if puppet_enabled -%>
 <%= snippet 'puppet_setup' %>
 <% end -%>
 
 <% if salt_enabled %>
 <%= snippet 'saltstack_setup' %>
-<% end -%>
-
-<% if spacewalk_enabled -%>
-<%= snippet 'redhat_register' %>
 <% end -%>
 
 <% if @host.respond_to?(:bootdisk_build?) && @host.bootdisk_build? %>

--- a/provisioning_templates/provision/kickstart_default.erb
+++ b/provisioning_templates/provision/kickstart_default.erb
@@ -234,11 +234,6 @@ redhat-lsb-core
 <% if host_param_true?('fips_enabled') -%>
 <%=   snippet 'fips_packages' %>
 <% end -%>
-
-
-<% if salt_enabled %>
-salt-minion
-<% end -%>
 <%= section_end -%>
 
 <% if @dynamic -%>

--- a/provisioning_templates/provision/preseed_default.erb
+++ b/provisioning_templates/provision/preseed_default.erb
@@ -109,7 +109,6 @@ d-i apt-setup/local<%= repos %>/repository string <%= medium[:url] %> <%= @host.
 <% end -%>
 
 <% if salt_enabled -%>
-<% salt_package = 'salt-minion' -%>
 <% if host_param_true?('enable-saltstack-repo') -%>
 <% if @host.operatingsystem.name == 'Debian' -%>
 d-i apt-setup/local<%= repos %>/repository string http://debian.saltstack.com/debian <%= @host.operatingsystem.release_name %>-saltstack main
@@ -124,8 +123,6 @@ d-i apt-setup/local<%= repos %>/key string http://keyserver.ubuntu.com/pks/looku
 <% repos += 1 -%>
 <% end -%>
 <% end -%>
-<% else -%>
-<% salt_package = '' -%>
 <% end -%>
 
 # Install minimal task set (see tasksel --task-packages minimal)

--- a/provisioning_templates/snippet/saltstack_setup.erb
+++ b/provisioning_templates/snippet/saltstack_setup.erb
@@ -21,6 +21,8 @@ if [ -f /usr/bin/dnf ]; then
 else
   yum -t -y install salt-minion
 fi
+<% elsif @host.operatingsystem.family == 'Suse' -%>
+  /usr/bin/zypper -n install salt-minion
 <% end -%>
 
 cat > <%= etc_path %>/minion << EOF


### PR DESCRIPTION
1. The salt-minion package is installed by the saltstack_setup snippet
2. salt (and puppet, too) should be executed after redhat_register (see kickstart_default provisioning) - autoyast_sles_default
3. get rid of salt_package which is no longer used in preseed