### PR TITLE
Update kickstart_default_user_data.erb

### DIFF
--- a/provisioning_templates/user_data/kickstart_default_user_data.erb
+++ b/provisioning_templates/user_data/kickstart_default_user_data.erb
@@ -68,10 +68,8 @@ fi
 
 <% if host_param_true?('ansible_tower_provisioning') -%>
     <%= save_to_file('/tmp/ansible_provisioning_call.sh', snippet('ansible_tower_callback_script')) %>
-    bash /tmp/ansible_provisioning_call.sh
+    /bin/sh /tmp/ansible_provisioning_call.sh
 <% end -%>
-
-
 
 # UserData still needs to mark the build as finished
 <%= snippet 'built' %>

--- a/provisioning_templates/user_data/kickstart_default_user_data.erb
+++ b/provisioning_templates/user_data/kickstart_default_user_data.erb
@@ -66,5 +66,12 @@ fi
 <%= snippet 'saltstack_setup' %>
 <% end -%>
 
+<% if host_param_true?('ansible_tower_provisioning') -%>
+    <%= save_to_file('/tmp/ansible_provisioning_call.sh', snippet('ansible_tower_callback_script')) %>
+    bash /tmp/ansible_provisioning_call.sh
+<% end -%>
+
+
+
 # UserData still needs to mark the build as finished
 <%= snippet 'built' %>


### PR DESCRIPTION
Added support for ansible tower provisioning callback. This is already in the finish template, adding here. Storing provisioning callback script  in /tmp so that the tmp directory cleaner will delete it in time, but it's there in the near term for inspection